### PR TITLE
feat: enhance TDD validation reliability

### DIFF
--- a/src/storage/FileStorage.ts
+++ b/src/storage/FileStorage.ts
@@ -50,6 +50,14 @@ export class FileStorage implements Storage {
   }
 
   async getTest(): Promise<string | null> {
+    try {
+      const stats = await fs.stat(this.filePaths.test)
+      const ageMs = Date.now() - stats.mtime.getTime()
+      const TWENTY_MINUTES_MS = 1200000 // 20 minutes in milliseconds
+      if (ageMs > TWENTY_MINUTES_MS) return null
+    } catch {
+      return null
+    }
     return this.get('test')
   }
 

--- a/src/validation/models/ClaudeCli.test.ts
+++ b/src/validation/models/ClaudeCli.test.ts
@@ -34,7 +34,7 @@ describe('ClaudeCli', () => {
         '--output-format',
         'json',
         '--max-turns',
-        '1',
+        '2',
         '--model',
         'sonnet',
       ])

--- a/src/validation/models/ClaudeCli.ts
+++ b/src/validation/models/ClaudeCli.ts
@@ -21,7 +21,7 @@ export class ClaudeCli implements IModelClient {
       '--output-format',
       'json',
       '--max-turns',
-      '1',
+      '2',
       '--model',
       'sonnet',
     ]

--- a/src/validation/prompts/response-format.ts
+++ b/src/validation/prompts/response-format.ts
@@ -24,7 +24,7 @@ When blocking, your reason must:
 - "Multiple test addition violation - adding 2 new tests simultaneously. Write and run only ONE test at a time to maintain TDD discipline."
 - "Over-implementation violation. Test fails with 'Calculator is not defined' but implementation adds both class AND method. Create only an empty class first, then run test again."
 - "Refactoring without passing tests. Test output shows failures. Fix failing tests first, ensure all pass, then refactor."
-- "Premature implementation - no test output available. Run the failing test first before implementing."
+- "Premature implementation - no test output available. Write the failing test first, run it with vitest/pytest to see it fail, then create the minimal implementation."
 
 #### Example Approval Reasons:
 - "Adding single test to test file - follows TDD red phase"


### PR DESCRIPTION
## Problem
TDD Guard had three critical reliability issues undermining TDD enforcement.

## Solution

**Stale test data causing false validations**
Added 20-minute test result expiry to prevent outdated validations

**Claude CLI response failures blocking workflows** 
Increased max-turns from 1→2 for better response reliability

**Vague error messages confusing developers**
Enhanced messages with specific `vitest/pytest` command guidance