### PR TITLE
feat: improve Claude CLI reliability

### DIFF
--- a/src/validation/models/ClaudeCli.test.ts
+++ b/src/validation/models/ClaudeCli.test.ts
@@ -34,7 +34,7 @@ describe('ClaudeCli', () => {
         '--output-format',
         'json',
         '--max-turns',
-        '1',
+        '2',
         '--model',
         'sonnet',
       ])

--- a/src/validation/models/ClaudeCli.ts
+++ b/src/validation/models/ClaudeCli.ts
@@ -21,7 +21,7 @@ export class ClaudeCli implements IModelClient {
       '--output-format',
       'json',
       '--max-turns',
-      '1',
+      '2',
       '--model',
       'sonnet',
     ]


### PR DESCRIPTION
## Problem
Single-turn Claude CLI responses occasionally failed, blocking TDD workflows.

## Solution
Increased --max-turns from 1→2. Not sure if 2 is optimal, but errors dropped drastically. Allows Claude to self-correct malformed JSON while maintaining efficiency.

Updated test expectations accordingly.