### PR TITLE
feat: add non-code file filtering to skip TDD validation

### DIFF
--- a/src/hooks/processHookData.test.ts
+++ b/src/hooks/processHookData.test.ts
@@ -140,6 +140,24 @@ describe('processHookData', () => {
     })
   })
 
+  describe('Non-code file filtering', () => {
+    it('should skip validation for markdown files', async () => {
+      const markdownFileData = {
+        ...EDIT_HOOK_DATA,
+        tool_input: {
+          file_path: '/path/to/README.md',
+          old_string: 'old content',
+          new_string: 'new content'
+        }
+      }
+
+      const result = await sut.process(markdownFileData)
+
+      expect(sut.validatorHasBeenCalled()).toBe(false)
+      expect(result).toEqual(defaultResult)
+    })
+  })
+
   describe('PreToolUse lint notification', () => {
     it('should block when tests pass, lint issues exist, and not yet notified', async () => {
       // Setup: passing tests
@@ -278,5 +296,6 @@ function createTestProcessor() {
     // Validator checks
     validatorHasBeenCalled: (): boolean => mockValidator.mock.calls.length > 0,
     getValidatorCallArgs: (): Context | null => mockValidator.mock.calls[0]?.[0] ?? null,
+    resetValidatorMock: (): void => mockValidator.mockClear(),
   }
 }

--- a/src/hooks/processHookData.ts
+++ b/src/hooks/processHookData.ts
@@ -76,7 +76,24 @@ function shouldSkipValidation(hookData: HookData): boolean {
     tool_input: hookData.tool_input,
   })
 
-  return !operationResult.success || isTodoWriteOperation(operationResult.data)
+  if (!operationResult.success || isTodoWriteOperation(operationResult.data)) {
+    return true
+  }
+
+  // Skip validation for non-code files
+  const toolInput = hookData.tool_input
+  if (toolInput && typeof toolInput === 'object' && 'file_path' in toolInput) {
+    const filePath = toolInput.file_path
+    if (typeof filePath === 'string') {
+      const nonCodeExtensions = ['.md', '.txt', '.log', '.json', '.yml', '.yaml', '.xml', '.html', '.css', '.rst']
+      const fileExt = filePath.toLowerCase().slice(filePath.lastIndexOf('.'))
+      if (nonCodeExtensions.includes(fileExt)) {
+        return true
+      }
+    }
+  }
+
+  return false
 }
 
 async function performValidation(deps: ProcessHookDataDeps, hookData?: unknown): Promise<ValidationResult> {


### PR DESCRIPTION
## Problem
TDD Guard was validating ALL file operations, including documentation and configuration files, which unnecessarily blocked non-code edits.

## Solution
Added file extension filtering in `shouldSkipValidation` to skip TDD validation for non-code files (.md, .txt, .log, .json, .yml, .yaml, .xml, .html, .css, .rst) while maintaining strict enforcement for code files.