### PR TITLE
Normalize ‘errored’ test state to ‘failed’ in PHPUnit reporter

### DIFF
--- a/reporters/phpunit/src/TestResultCollector.php
+++ b/reporters/phpunit/src/TestResultCollector.php
@@ -82,10 +82,15 @@ final class TestResultCollector
                     'tests' => [],
                 ];
             }
-            $modules[$moduleId]['tests'][] = $item['test'];
 
-            // Check if any test failed
-            if ($item['test']['state'] === 'failed' || $item['test']['state'] === 'errored') {
+            // Normalize 'errored' to 'failed'
+            $test = $item['test'];
+            if ($test['state'] === 'errored') {
+                $test['state'] = 'failed';
+            }
+            $modules[$moduleId]['tests'][] = $test;
+
+            if ($test['state'] === 'failed') {
                 $hasFailures = true;
             }
         }

--- a/reporters/phpunit/tests/TddGuardExtensionFailedTest.php
+++ b/reporters/phpunit/tests/TddGuardExtensionFailedTest.php
@@ -129,9 +129,64 @@ class ErroredTest extends TestCase {
         $module = $data['testModules'][0];
         $test = $module['tests'][0];
         $this->assertEquals('testWithError', $test['name']);
-        $this->assertEquals('errored', $test['state']);
+        $this->assertEquals('failed', $test['state']);
         $this->assertArrayHasKey('errors', $test);
         $this->assertStringContainsString('Something went terribly wrong!', $test['errors'][0]['message']);
+    }
+
+    public function testErroredStateIsNormalizedToFailed(): void
+    {
+        // This test ensures 'errored' states are normalized to 'failed' for TDD Guard compatibility
+        // Prevents regression where errored states break schema validation
+
+        // Given: A test file that will cause a PHP error
+        $testFile = $this->tempDir . '/ErrorTest.php';
+        file_put_contents($testFile, '<?php
+use PHPUnit\Framework\TestCase;
+
+class ErrorTest extends TestCase
+{
+    public function testUndefinedMethod(): void
+    {
+        $this->nonExistentMethod(); // This will cause a PHP error
+    }
+}
+');
+
+        // When: PHPUnit runs with TDD Guard extension
+        $phpunitXml = $this->tempDir . '/phpunit.xml';
+        file_put_contents($phpunitXml, '<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+         bootstrap="' . dirname(__DIR__) . '/vendor/autoload.php"
+         colors="true">
+  <extensions>
+    <bootstrap class="TddGuard\\PHPUnit\\TddGuardExtension"/>
+  </extensions>
+  <testsuites>
+    <testsuite name="test">
+      <file>' . $testFile . '</file>
+    </testsuite>
+  </testsuites>
+</phpunit>');
+
+        $command = sprintf(
+            'cd %s && php %s/vendor/bin/phpunit -c %s 2>&1',
+            escapeshellarg($this->tempDir),
+            escapeshellarg(dirname(__DIR__)),
+            escapeshellarg($phpunitXml)
+        );
+        exec($command, $output, $returnCode);
+
+        // Then: The errored test should be normalized to 'failed' state
+        $this->assertNotEquals(0, $returnCode, 'PHPUnit should exit with non-zero');
+        $jsonPath = $this->tempDir . '/.claude/tdd-guard/data/test.json';
+        $this->assertFileExists($jsonPath);
+        $data = json_decode(file_get_contents($jsonPath), true);
+
+        $test = $data['testModules'][0]['tests'][0];
+        $this->assertEquals('failed', $test['state'], 'Errored test should be normalized to failed state');
+        $this->assertArrayHasKey('errors', $test, 'Failed test should have error details');
     }
 
     public function testExtensionCapturesSkippedTest(): void

--- a/reporters/test/reporters.integration.test.ts
+++ b/reporters/test/reporters.integration.test.ts
@@ -261,7 +261,7 @@ describe('Reporters', () => {
       }> = [
         { name: 'jest', expected: 'failed' },
         { name: 'vitest', expected: undefined },
-        { name: 'phpunit', expected: 'errored' },
+        { name: 'phpunit', expected: 'failed' },
         { name: 'pytest', expected: 'failed' },
       ]
 


### PR DESCRIPTION
- Normalize PHPUnit 'errored' test states to 'failed' in test result output
- Ensure consistent schema compliance across all test reporters
- Add comprehensive test coverage for error state normalization

## Problem

PHPUnit distinguishes between 'failed' tests (assertion failures) and 'errored' tests (PHP errors, exceptions). However, TDD Guard's validation schema expects only 'failed' states for unsuccessful tests, causing schema validation issues when PHPUnit reports 'errored' states.

##  Solution

Modified TestResultCollector.php to normalize 'errored' states to 'failed' before saving results.
