### PR TITLE
feat: add golangci-lint support for Go projects

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,7 @@ USE_SYSTEM_CLAUDE=false
 TDD_GUARD_ANTHROPIC_API_KEY=
 
 # Linter type for refactoring phase support (optional)
-# Options: 'eslint' or unset (no linting)
+# Options: 'eslint', 'golangci-lint' or unset (no linting)
 # Only set this if you want automatic code quality checks during refactoring
 # LINTER_TYPE=eslint
 

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -84,8 +84,8 @@ export class Config {
   }
 
   private getLinterType(options?: ConfigOptions): string | undefined {
-    if (options?.linterType) {
-      return options.linterType.toLowerCase()
+    if (options && 'linterType' in options) {
+      return options.linterType?.toLowerCase()
     }
     const envValue = process.env.LINTER_TYPE?.toLowerCase()
     return envValue && envValue.trim() !== '' ? envValue : undefined

--- a/src/contracts/schemas/lintSchemas.ts
+++ b/src/contracts/schemas/lintSchemas.ts
@@ -1,5 +1,35 @@
 import { z } from 'zod'
 
+export const ESLintMessageSchema = z.object({
+  line: z.number().optional(),
+  column: z.number().optional(),
+  severity: z.number(),
+  message: z.string(),
+  ruleId: z.string().optional(),
+})
+
+export const ESLintResultSchema = z.object({
+  filePath: z.string(),
+  messages: z.array(ESLintMessageSchema).optional(),
+})
+
+export const GolangciLintPositionSchema = z.object({
+  Filename: z.string(),
+  Line: z.number(),
+  Column: z.number(),
+})
+
+export const GolangciLintIssueSchema = z.object({
+  FromLinter: z.string(),
+  Text: z.string(),
+  Severity: z.string(),
+  Pos: GolangciLintPositionSchema,
+})
+
+export const GolangciLintResultSchema = z.object({
+  Issues: z.array(GolangciLintIssueSchema).optional(),
+})
+
 export const LintIssueSchema = z.object({
   file: z.string(),
   line: z.number(),
@@ -21,21 +51,10 @@ export const LintDataSchema = LintResultSchema.extend({
   hasNotifiedAboutLintIssues: z.boolean(),
 })
 
-export const ESLintMessageSchema = z.object({
-  line: z.number().optional(),
-  column: z.number().optional(),
-  severity: z.number(),
-  message: z.string(),
-  ruleId: z.string().optional(),
-})
-
-export const ESLintResultSchema = z.object({
-  filePath: z.string(),
-  messages: z.array(ESLintMessageSchema).optional(),
-})
-
-export type LintIssue = z.infer<typeof LintIssueSchema>
-export type LintResult = z.infer<typeof LintResultSchema>
-export type LintData = z.infer<typeof LintDataSchema>
 export type ESLintMessage = z.infer<typeof ESLintMessageSchema>
 export type ESLintResult = z.infer<typeof ESLintResultSchema>
+export type GolangciLintIssue = z.infer<typeof GolangciLintIssueSchema>
+export type GolangciLintResult = z.infer<typeof GolangciLintResultSchema>
+export type LintData = z.infer<typeof LintDataSchema>
+export type LintIssue = z.infer<typeof LintIssueSchema>
+export type LintResult = z.infer<typeof LintResultSchema>

--- a/src/linters/eslint/ESLint.test.ts
+++ b/src/linters/eslint/ESLint.test.ts
@@ -1,10 +1,12 @@
 import { describe, test, expect, beforeEach } from 'vitest'
 import { ESLint } from './ESLint'
 import { join } from 'path'
-import { LintIssue, LintResult } from '../../contracts/schemas/lintSchemas'
+import { LintResult } from '../../contracts/schemas/lintSchemas'
+import { hasRules, issuesFromFile } from '../../../test/utils/assertions'
 
 describe('ESLint', () => {
   let linter: ESLint
+
   beforeEach(() => {
     linter = new ESLint()
   })
@@ -19,6 +21,7 @@ describe('ESLint', () => {
     expect(result).toBeDefined()
     expect(result.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
   })
+
   test('returns the file paths that were passed in', async () => {
     const filePaths = ['src/file1.ts', 'src/file2.ts']
     const result = await linter.lint(filePaths)
@@ -126,16 +129,3 @@ describe('ESLint', () => {
     })
   })
 })
-
-// Test helper functions
-function hasRule(issues: LintIssue[], rule: string): boolean {
-  return issues.some((issue) => issue.rule === rule)
-}
-
-function hasRules(issues: LintIssue[], rules: string[]): boolean[] {
-  return rules.map((rule) => hasRule(issues, rule))
-}
-
-function issuesFromFile(issues: LintIssue[], filename: string): LintIssue[] {
-  return issues.filter((issue) => issue.file.includes(filename))
-}

--- a/src/linters/golangci/GolangciLint.test.ts
+++ b/src/linters/golangci/GolangciLint.test.ts
@@ -1,0 +1,156 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+import { GolangciLint } from './GolangciLint'
+import { join } from 'path'
+import { execFile } from 'child_process'
+import { setupGolangciMock } from '../../../test/utils/mocks/golangci'
+import { hasRules, issuesFromFile } from '../../../test/utils/assertions'
+
+// Mock execFile to avoid requiring system golangci-lint
+vi.mock('child_process', () => ({
+  execFile: vi.fn(),
+}))
+
+// Get type-safe reference to the mocked function
+const mockedExecFile = vi.mocked(execFile)
+
+// Test artifacts directory - defined once for reuse
+const artifactsDir = join(__dirname, '../../../test/artifacts')
+const configPath = join(artifactsDir, '.golangci.yml')
+
+describe('GolangciLint', () => {
+  let linter: GolangciLint
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    setupGolangciMock(mockedExecFile)
+    linter = new GolangciLint()
+  })
+
+  describe('basic functionality', () => {
+    test('can be instantiated', () => {
+      expect(linter).toBeDefined()
+    })
+
+    test('implements Linter interface with lint method', async () => {
+      const result = await linter.lint([])
+
+      expect(result).toBeDefined()
+      expect(result.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
+    })
+
+    test('returns the file paths that were passed in', async () => {
+      const filePaths = ['main.go', 'pkg/handler.go']
+      const result = await linter.lint(filePaths)
+
+      expect(result.files).toEqual(filePaths)
+    })
+  })
+
+  describe('linting behavior', () => {
+    test('detects issues in file with lint problems', async () => {
+      const filePath = join(artifactsDir, 'file-with-issues.go')
+      const result = await linter.lint([filePath], configPath)
+
+      expect(result.issues.length).toBeGreaterThan(0)
+      expect(result.errorCount).toBeGreaterThan(0)
+
+      // Check for specific rules that should be detected
+      const expectedRules = ['typecheck', 'ineffassign']
+      const ruleResults = hasRules(result.issues, expectedRules)
+
+      ruleResults.forEach((ruleExists) => {
+        expect(ruleExists).toBe(true)
+      })
+    })
+
+    test('returns specific golangci-lint message for undefined variable', async () => {
+      const filePath = join(artifactsDir, 'file-with-issues.go')
+      const result = await linter.lint([filePath])
+
+      const undefinedVarIssue = result.issues.find((issue) =>
+        issue.message.includes('undefined: messag')
+      )
+      expect(undefinedVarIssue).toMatchObject({
+        rule: 'typecheck',
+        message: expect.stringContaining('undefined: messag'),
+      })
+    })
+
+    test('returns no issues for clean Go file', async () => {
+      const filePath = join(artifactsDir, 'file-without-issues.go')
+      const result = await linter.lint([filePath])
+
+      expect(result.issues.length).toBe(0)
+      expect(result.errorCount).toBe(0)
+    })
+
+    test('returns exactly 3 issues for problematic file', async () => {
+      const filePath = join(artifactsDir, 'file-with-issues.go')
+      const result = await linter.lint([filePath])
+
+      expect(result.issues.length).toBe(3)
+      expect(result.errorCount).toBe(3)
+    })
+
+    test('returns different results for different files', async () => {
+      const problemFile = join(artifactsDir, 'file-with-issues.go')
+      const cleanFile = join(artifactsDir, 'file-without-issues.go')
+
+      const problemResult = await linter.lint([problemFile])
+      const cleanResult = await linter.lint([cleanFile])
+
+      expect(problemResult.issues.length).toBeGreaterThan(0)
+      expect(cleanResult.issues.length).toBe(0)
+    })
+
+    test('processes multiple files correctly', async () => {
+      const files = [
+        join(artifactsDir, 'file-with-issues.go'),
+        join(artifactsDir, 'file-without-issues.go'),
+      ]
+      const result = await linter.lint(files)
+
+      expect(result.files).toEqual(files)
+      expect(result.issues.length).toBeGreaterThan(0)
+
+      // Issues should only be from the file with issues
+      const cleanFileIssues = issuesFromFile(
+        result.issues,
+        'file-without-issues.go'
+      )
+      expect(cleanFileIssues.length).toBe(0)
+    })
+  })
+
+  describe('with files containing special characters', () => {
+    test.each([
+      ['spaces', 'src/my file with spaces.go'],
+      ['quotes', 'src/file"with"quotes.go'],
+      ['semicolons', 'src/file;name.go'],
+      ['backticks', 'src/file`with`backticks.go'],
+      ['dollar signs', 'src/file$with$dollar.go'],
+      ['pipes', 'src/file|with|pipes.go'],
+      ['ampersands', 'src/file&with&ampersands.go'],
+      ['parentheses', 'src/file(with)parentheses.go'],
+      ['command injection attempt', 'file.go"; cat /etc/passwd; echo "'],
+      ['newlines', 'src/file\nwith\nnewlines.go'],
+      ['tabs', 'src/file\twith\ttabs.go'],
+    ])('handles file paths with %s correctly', async (_, filePath) => {
+      const result = await linter.lint([filePath])
+
+      expect(result.files).toEqual([filePath])
+      expect(result.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
+    })
+
+    test.each([
+      ['spaces', '/path with spaces/.golangci.yml'],
+      ['quotes', '/path"with"quotes/.golangci.yml'],
+      ['special chars', '/path;with&special|chars/.golangci.yml'],
+    ])('handles config paths with %s correctly', async (_, configFilePath) => {
+      const result = await linter.lint(['main.go'], configFilePath)
+
+      expect(result.files).toEqual(['main.go'])
+      expect(result.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
+    })
+  })
+})

--- a/src/linters/golangci/GolangciLint.ts
+++ b/src/linters/golangci/GolangciLint.ts
@@ -1,0 +1,100 @@
+import {
+  LintResult,
+  LintIssue,
+  GolangciLintIssue,
+  GolangciLintResult,
+} from '../../contracts/schemas/lintSchemas'
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import { Linter } from '../Linter'
+
+const execFileAsync = promisify(execFile)
+
+export class GolangciLint implements Linter {
+  async lint(filePaths: string[], configPath?: string): Promise<LintResult> {
+    const timestamp = new Date().toISOString()
+    const args = buildArgs(filePaths, configPath)
+
+    try {
+      await execFileAsync('golangci-lint', args)
+      return createLintData(timestamp, filePaths, [])
+    } catch (error) {
+      if (!isExecError(error)) {
+        return createLintData(timestamp, filePaths, [])
+      }
+
+      const results = parseResults(error.stdout)
+      return createLintData(timestamp, filePaths, results)
+    }
+  }
+}
+
+// Helper functions
+const buildArgs = (files: string[], configPath?: string): string[] => {
+  const args = ['run', '--output.json.path=stdout']
+
+  if (configPath !== undefined) {
+    args.push('--config', configPath)
+  } else {
+    args.push('--no-config')
+  }
+  args.push(...files)
+
+  return args
+}
+
+const isExecError = (error: unknown): error is Error & { stdout?: string } =>
+  error !== null && typeof error === 'object' && 'stdout' in error
+
+// Parse golangci-lint JSON output - only first line contains JSON, rest is summary
+const parseResults = (stdout?: string): GolangciLintIssue[] => {
+  try {
+    if (stdout === undefined || stdout === '') {
+      return []
+    }
+
+    const lines = stdout.split('\n')
+    const jsonLine = lines[0]
+    if (jsonLine.trim() === '') {
+      return []
+    }
+
+    const parsed: GolangciLintResult = JSON.parse(jsonLine)
+    return parsed.Issues ?? []
+  } catch {
+    return []
+  }
+}
+
+const createLintData = (
+  timestamp: string,
+  files: string[],
+  results: GolangciLintIssue[]
+): LintResult => {
+  const issues = extractIssues(results)
+
+  return {
+    timestamp,
+    files,
+    issues,
+    errorCount: countBySeverity(issues, 'error'),
+    warningCount: countBySeverity(issues, 'warning'),
+  }
+}
+
+const extractIssues = (results: GolangciLintIssue[]): LintIssue[] =>
+  results.map(toIssue)
+
+const toIssue = (issue: GolangciLintIssue): LintIssue => ({
+  file: issue.Pos.Filename,
+  line: issue.Pos.Line,
+  column: issue.Pos.Column,
+  severity: 'error' as const, // golangci-lint doesn't provide severity levels
+  message: issue.Text,
+  rule: issue.FromLinter,
+})
+
+const countBySeverity = (
+  issues: LintIssue[],
+  severity: 'error' | 'warning'
+): number => issues.filter((i) => i.severity === severity).length

--- a/src/providers/LinterProvider.test.ts
+++ b/src/providers/LinterProvider.test.ts
@@ -1,9 +1,26 @@
-import { describe, test, expect } from 'vitest'
+import { describe, test, expect, beforeEach, afterEach } from 'vitest'
 import { LinterProvider } from './LinterProvider'
 import { Config } from '../config/Config'
 import { ESLint } from '../linters/eslint/ESLint'
+import { GolangciLint } from '../linters/golangci/GolangciLint'
 
 describe('LinterProvider', () => {
+  let originalLinterType: string | undefined
+
+  beforeEach(() => {
+    // Save original environment variable
+    originalLinterType = process.env.LINTER_TYPE
+  })
+
+  afterEach(() => {
+    // Restore original environment variable
+    if (originalLinterType === undefined) {
+      delete process.env.LINTER_TYPE
+    } else {
+      process.env.LINTER_TYPE = originalLinterType
+    }
+  })
+
   test('returns ESLint when config linterType is eslint', () => {
     const config = new Config({ linterType: 'eslint' })
 
@@ -13,7 +30,16 @@ describe('LinterProvider', () => {
     expect(linter).toBeInstanceOf(ESLint)
   })
 
-  test('returns null when config linterType is undefined', () => {
+  test('returns GolangciLint when config linterType is golangci-lint', () => {
+    const config = new Config({ linterType: 'golangci-lint' })
+
+    const provider = new LinterProvider()
+    const linter = provider.getLinter(config)
+
+    expect(linter).toBeInstanceOf(GolangciLint)
+  })
+
+  test('returns null when config linterType is explicitly undefined', () => {
     const config = new Config({ linterType: undefined })
 
     const provider = new LinterProvider()
@@ -22,10 +48,59 @@ describe('LinterProvider', () => {
     expect(linter).toBeNull()
   })
 
-  test('uses default config when no config is provided', () => {
-    const provider = new LinterProvider()
-    const linter = provider.getLinter()
+  test('returns null when config linterType is unknown value', () => {
+    const config = new Config({ linterType: 'unknown-linter' })
 
-    expect(linter).toBeNull() // Default linterType is undefined
+    const provider = new LinterProvider()
+    const linter = provider.getLinter(config)
+
+    expect(linter).toBeNull()
+  })
+
+  describe('with environment variables', () => {
+    test('returns ESLint when LINTER_TYPE env var is eslint', () => {
+      process.env.LINTER_TYPE = 'eslint'
+
+      const provider = new LinterProvider()
+      const linter = provider.getLinter()
+
+      expect(linter).toBeInstanceOf(ESLint)
+    })
+
+    test('returns GolangciLint when LINTER_TYPE env var is golangci-lint', () => {
+      process.env.LINTER_TYPE = 'golangci-lint'
+
+      const provider = new LinterProvider()
+      const linter = provider.getLinter()
+
+      expect(linter).toBeInstanceOf(GolangciLint)
+    })
+
+    test('returns null when LINTER_TYPE env var is unset', () => {
+      delete process.env.LINTER_TYPE
+
+      const provider = new LinterProvider()
+      const linter = provider.getLinter()
+
+      expect(linter).toBeNull()
+    })
+
+    test('returns null when LINTER_TYPE env var is empty string', () => {
+      process.env.LINTER_TYPE = ''
+
+      const provider = new LinterProvider()
+      const linter = provider.getLinter()
+
+      expect(linter).toBeNull()
+    })
+
+    test('returns null when LINTER_TYPE env var is unknown value', () => {
+      process.env.LINTER_TYPE = 'unknown-linter'
+
+      const provider = new LinterProvider()
+      const linter = provider.getLinter()
+
+      expect(linter).toBeNull()
+    })
   })
 })

--- a/src/providers/LinterProvider.ts
+++ b/src/providers/LinterProvider.ts
@@ -1,15 +1,20 @@
 import { Linter } from '../linters/Linter'
 import { Config } from '../config/Config'
 import { ESLint } from '../linters/eslint/ESLint'
+import { GolangciLint } from '../linters/golangci/GolangciLint'
 
 export class LinterProvider {
   getLinter(config?: Config): Linter | null {
     const actualConfig = config ?? new Config()
 
-    if (actualConfig.linterType === 'eslint') {
-      return new ESLint()
+    switch (actualConfig.linterType) {
+      case 'eslint':
+        return new ESLint()
+      case 'golangci-lint':
+        return new GolangciLint()
+      case undefined:
+      default:
+        return null
     }
-
-    return null
   }
 }

--- a/test/artifacts/.golangci.yml
+++ b/test/artifacts/.golangci.yml
@@ -1,0 +1,6 @@
+version: 2
+linters:
+  enable:
+    - govet
+    - errcheck
+    - ineffassign

--- a/test/artifacts/file-with-issues.go
+++ b/test/artifacts/file-with-issues.go
@@ -1,0 +1,11 @@
+package main
+
+import "fmt"
+
+func main() {
+	var unused int // ineffassign: ineffectual assignment
+	message := "Hello"
+
+	fmt.Println(messag) // typecheck: undefined variable
+}
+

--- a/test/artifacts/file-without-issues.go
+++ b/test/artifacts/file-without-issues.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+    fmt.Println("Hello, World!")
+}

--- a/test/utils/assertions.ts
+++ b/test/utils/assertions.ts
@@ -1,0 +1,29 @@
+/**
+ * Test assertion helpers for linter tests
+ */
+
+import type { LintIssue } from '../../src/contracts/schemas/lintSchemas'
+
+/**
+ * Check if issues contain a specific rule
+ */
+export const hasRule = (issues: LintIssue[], rule: string): boolean => {
+  return issues.some((issue) => issue.rule === rule)
+}
+
+/**
+ * Check if issues contain all specified rules
+ */
+export const hasRules = (issues: LintIssue[], rules: string[]): boolean[] => {
+  return rules.map((rule) => hasRule(issues, rule))
+}
+
+/**
+ * Filter issues from a specific file
+ */
+export const issuesFromFile = (
+  issues: LintIssue[],
+  filename: string
+): LintIssue[] => {
+  return issues.filter((issue) => issue.file.includes(filename))
+}

--- a/test/utils/mocks/golangci.ts
+++ b/test/utils/mocks/golangci.ts
@@ -1,0 +1,105 @@
+import type { ExecFileException, execFile } from 'child_process'
+import type { MockedFunction } from 'vitest'
+
+export interface GolangciIssue {
+  FromLinter: string
+  Text: string
+  Pos: {
+    Filename: string
+    Line: number
+    Column: number
+  }
+}
+
+export interface GolangciOutput {
+  Issues: GolangciIssue[]
+}
+
+export const createGolangciMockResponse = (): {
+  withIssues: () => GolangciOutput
+  withoutIssues: () => GolangciOutput
+  version: () => string
+} => {
+  const mockIssues: GolangciIssue[] = [
+    {
+      FromLinter: 'typecheck',
+      Text: 'undefined: messag',
+      Pos: {
+        Filename: 'test/artifacts/file-with-issues.go',
+        Line: 9,
+        Column: 14,
+      },
+    },
+    {
+      FromLinter: 'ineffassign',
+      Text: 'ineffectual assignment to unused',
+      Pos: {
+        Filename: 'test/artifacts/file-with-issues.go',
+        Line: 6,
+        Column: 2,
+      },
+    },
+    {
+      FromLinter: 'typecheck',
+      Text: 'unused variable',
+      Pos: {
+        Filename: 'test/artifacts/file-with-issues.go',
+        Line: 6,
+        Column: 2,
+      },
+    },
+  ]
+
+  return {
+    withIssues: (): GolangciOutput => ({ Issues: mockIssues }),
+    withoutIssues: (): GolangciOutput => ({ Issues: [] }),
+    version: () => 'golangci-lint has version 1.55.2',
+  }
+}
+
+export const setupGolangciMock = (
+  mockExecFile: MockedFunction<typeof execFile>
+): void => {
+  const responses = createGolangciMockResponse()
+
+  mockExecFile.mockImplementation(((...args: Parameters<typeof execFile>) => {
+    const [command, argsOrCallback, callbackOrOptions, maybeCallback] = args
+
+    let actualArgs: readonly string[] = []
+    let callback: (
+      error: ExecFileException | null,
+      stdout: string,
+      stderr: string
+    ) => void
+
+    if (Array.isArray(argsOrCallback)) {
+      actualArgs = argsOrCallback
+      callback = (callbackOrOptions ?? maybeCallback) as typeof callback
+    } else if (typeof argsOrCallback === 'function') {
+      callback = argsOrCallback as typeof callback
+    } else {
+      callback = (callbackOrOptions ?? maybeCallback) as typeof callback
+    }
+
+    if (command === 'golangci-lint' && actualArgs[0] === '--version') {
+      callback(null, responses.version(), '')
+      return {} as ReturnType<typeof execFile>
+    }
+
+    if (
+      command === 'golangci-lint' &&
+      actualArgs.some((arg: string) => arg.includes('file-with-issues.go'))
+    ) {
+      const mockOutput = JSON.stringify(responses.withIssues())
+      const error = new Error('golangci-lint found issues') as ExecFileException
+
+      error.stdout = mockOutput
+      callback(error, '', '')
+      return {} as ReturnType<typeof execFile>
+    }
+
+    // No issues found for other files
+    callback(null, '', '')
+    return {} as ReturnType<typeof execFile>
+  }) as typeof execFile)
+}


### PR DESCRIPTION
## Summary

Adds golangci-lint support for Go projects. TDD Guard can now enforce code quality checks for Go during the refactoring phase, alongside the existing ESLint support.

## Changes

- **Added golangci-lint integration**: New `GolangciLint` class that parses golangci-lint JSON output
- **Updated linter provider**: `LinterProvider` now handles `golangci-lint` configuration option  
- **Extracted test utilities**: Shared test helpers to reduce duplication across linter tests
- **Added configuration support**: `golangci-lint` is now a valid `LINTER_TYPE` option
- **Added test coverage**: Tests with Go artifacts that demonstrate issue detection

## Test Plan

- [ ] Verify golangci-lint works with `LINTER_TYPE=golangci-lint`
- [x] Confirm ESLint still works with existing configuration
- [ ] Test both linters detect and report issues correctly
- [ ] Check missing linter binaries are handled gracefully
- [ ] Verify refactoring phase blocks on lint issues for Go files