### PR TITLE
feat(reporters): make Go reporter closer match go test and improve truncation

### DIFF
--- a/reporters/go/internal/formatter/formatter.go
+++ b/reporters/go/internal/formatter/formatter.go
@@ -49,9 +49,12 @@ func (f *Formatter) handleBuildOutput(event parser.TestEvent) string {
 
 func (f *Formatter) handleBuildFail(event parser.TestEvent) string {
 	if event.Package != "" {
-		return fmt.Sprintf("BUILD FAILED\t%s", event.Package)
+		return fmt.Sprintf("FAIL\t%s [build failed]", event.Package)
 	}
-	return "BUILD FAILED"
+	if event.ImportPath != "" {
+		return fmt.Sprintf("FAIL\t%s [build failed]", event.ImportPath)
+	}
+	return "FAIL\t[build failed]"
 }
 
 // handleOutput filters redundant output lines and preserves error messages.


### PR DESCRIPTION
- Handle race condition output with file location preservation
- Improve build failure formatting with consistent FAIL markers
- Prioritize file:line information in truncated output for better debugging