### PR TITLE
fix: ensure cross-platform compatibility for Windows execution

### DIFF
--- a/src/cli/tdd-guard.test.ts
+++ b/src/cli/tdd-guard.test.ts
@@ -15,7 +15,7 @@ describe('tdd-guard CLI', () => {
   describe('CLI Behavior', () => {
     test('has shebang for direct execution', async () => {
       const content = await fs.readFile(cliPath, 'utf-8')
-      const firstLine = content.split('\n')[0]
+      const firstLine = content.split('\n')[0].trim()
 
       expect(firstLine).toBe('#!/usr/bin/env node')
     })
@@ -137,7 +137,7 @@ async function runCli(
     const npxPath = process.platform === 'win32' ? 'npx.cmd' : 'npx'
     const proc = spawn(npxPath, ['tsx', cliPath], {
       env: { ...process.env },
-      shell: false,
+      shell: process.platform === 'win32',
     })
 
     let stderr = ''

--- a/src/config/Config.test.ts
+++ b/src/config/Config.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, beforeEach, afterEach } from 'vitest'
 import { Config } from './Config'
+import path from 'path'
 
 describe('Config', () => {
   const originalEnv = process.env
@@ -14,7 +15,7 @@ describe('Config', () => {
 
   describe('dataDir', () => {
     const projectRoot = '/test/project'
-    const projectDataDir = `${projectRoot}/${Config.DEFAULT_DATA_DIR}`
+    const projectDataDir = path.join(projectRoot, Config.DEFAULT_DATA_DIR)
     let config: Config
 
     beforeEach(() => {
@@ -31,30 +32,34 @@ describe('Config', () => {
     })
 
     test('testResultsFilePath returns test.json path within dataDir', () => {
-      expect(config.testResultsFilePath).toBe(`${projectDataDir}/test.json`)
+      expect(config.testResultsFilePath).toBe(
+        path.join(projectDataDir, 'test.json')
+      )
     })
 
     test('todosFilePath returns todos.json path within dataDir', () => {
-      expect(config.todosFilePath).toBe(`${projectDataDir}/todos.json`)
+      expect(config.todosFilePath).toBe(path.join(projectDataDir, 'todos.json'))
     })
 
     test('modificationsFilePath returns modifications.json path within dataDir', () => {
       expect(config.modificationsFilePath).toBe(
-        `${projectDataDir}/modifications.json`
+        path.join(projectDataDir, 'modifications.json')
       )
     })
 
     test('lintFilePath returns lint.json path within dataDir', () => {
-      expect(config.lintFilePath).toBe(`${projectDataDir}/lint.json`)
+      expect(config.lintFilePath).toBe(path.join(projectDataDir, 'lint.json'))
     })
 
     test('configFilePath returns config.json path within dataDir', () => {
-      expect(config.configFilePath).toBe(`${projectDataDir}/config.json`)
+      expect(config.configFilePath).toBe(
+        path.join(projectDataDir, 'config.json')
+      )
     })
 
     test('instructionsFilePath returns instructions.md path within dataDir', () => {
       expect(config.instructionsFilePath).toBe(
-        `${projectDataDir}/instructions.md`
+        path.join(projectDataDir, 'instructions.md')
       )
     })
 
@@ -78,7 +83,7 @@ describe('Config', () => {
         const configWithClaudeDir = new Config()
 
         expect(configWithClaudeDir.dataDir).toBe(
-          `${claudeProjectDir}/${Config.DEFAULT_DATA_DIR}`
+          path.join(claudeProjectDir, Config.DEFAULT_DATA_DIR)
         )
       })
 
@@ -90,7 +95,7 @@ describe('Config', () => {
         const configWithBoth = new Config({ projectRoot: explicitProjectRoot })
 
         expect(configWithBoth.dataDir).toBe(
-          `${explicitProjectRoot}/${Config.DEFAULT_DATA_DIR}`
+          path.join(explicitProjectRoot, Config.DEFAULT_DATA_DIR)
         )
       })
 

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -9,7 +9,7 @@ const CONFIG_FILENAME = 'config.json'
 const INSTRUCTIONS_FILENAME = 'instructions.md'
 
 export class Config {
-  static readonly DEFAULT_DATA_DIR = '.claude/tdd-guard/data' as const
+  static readonly DEFAULT_DATA_DIR = path.join('.claude', 'tdd-guard', 'data')
 
   readonly dataDir: string
   readonly useSystemClaude: boolean
@@ -33,7 +33,7 @@ export class Config {
 
     // If we have a base directory, construct the full path
     if (baseDir) {
-      return path.join(baseDir, ...Config.DEFAULT_DATA_DIR.split('/'))
+      return path.join(baseDir, Config.DEFAULT_DATA_DIR)
     }
 
     // Default to relative path

--- a/src/linters/eslint/ESLint.ts
+++ b/src/linters/eslint/ESLint.ts
@@ -16,7 +16,7 @@ export class ESLint implements Linter {
     const args = buildArgs(filePaths, configPath)
 
     try {
-      await execFileAsync('npx', args)
+      await execFileAsync('npx', args, { shell: process.platform === 'win32' })
       return createLintData(timestamp, filePaths, [])
     } catch (error) {
       if (!isExecError(error)) throw error

--- a/src/validation/models/ClaudeCli.ts
+++ b/src/validation/models/ClaudeCli.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from 'child_process'
 import { join } from 'path'
+import { homedir } from 'os'
 import { existsSync, mkdirSync } from 'fs'
 import { IModelClient } from '../../contracts/types/ModelClient'
 import { Config } from '../../config/Config'
@@ -12,9 +13,7 @@ export class ClaudeCli implements IModelClient {
   }
 
   async ask(prompt: string): Promise<string> {
-    const claudeBinary = this.config.useSystemClaude
-      ? 'claude'
-      : `${process.env.HOME}/.claude/local/claude`
+    const claudeBinary = this.getClaudeBinary()
 
     const args = [
       '-',
@@ -39,11 +38,20 @@ export class ClaudeCli implements IModelClient {
       timeout: 60000,
       input: prompt,
       cwd: claudeDir,
+      shell: process.platform === 'win32',
     })
 
     // Parse the Claude CLI response and extract the result field
     const response = JSON.parse(output)
 
     return response.result
+  }
+
+  private getClaudeBinary(): string {
+    if (this.config.useSystemClaude) {
+      return 'claude'
+    }
+
+    return join(homedir(), '.claude', 'local', 'claude')
   }
 }


### PR DESCRIPTION
## Summary
- Fixes TDD Guard execution on Windows platforms
- Ensures all file paths are platform-agnostic

## Problem
TDD Guard was failing on Windows due to:
1. **Process execution issues**: Windows requires `shell: true` to execute `.cmd`/`.bat` files (npx, claude)
2. **Path separator issues**: Hardcoded forward slashes breaking on Windows
3. **Environment variable issues**: `$HOME` not available on Windows

## Solution
- Added `shell: process.platform === 'win32'` to relevant process execution calls
- Replaced all hardcoded path separators with `path.join()`
- Used `os.homedir()` instead of `$HOME` environment variable
- Fixed line ending handling in tests for cross-platform compatibility

**Note:** Using PR workflow for security review of shell execution changes to ensure no command injection vulnerabilities are introduced.