### PR TITLE
Fix typo for UserPromptSubmit hook in manual configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ If you prefer to edit settings files directly, add all three hooks to your chose
         ]
       }
     ],
-    "userpromptsubmit": [
+    "UserPromptSubmit": [
       {
         "hooks": [
           {


### PR DESCRIPTION
Change `userpromptsubmit` (invalid) to `UserPromptSubmit`