### PR TITLE
feat: add support for Z.AI (GLM 4.7) as alternative API provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,11 @@ TDD_GUARD_MODEL_VERSION=claude-sonnet-4-0
 # Get your API key from https://console.anthropic.com/
 TDD_GUARD_ANTHROPIC_API_KEY=
 
+# Anthropic API Base URL (optional)
+# Use for alternative API providers like Z.AI (GLM models)
+# See docs/glm-configuration.md for detailed Z.AI setup
+# TDD_GUARD_ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic
+
 # Linter type for refactoring phase support (optional)
 # Options: 'eslint', 'golangci-lint' or unset (no linting)
 # Only set this if you want automatic code quality checks during refactoring

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,6 +24,11 @@ TDD_GUARD_MODEL_VERSION=claude-sonnet-4-0
 # Get your API key from https://console.anthropic.com/
 TDD_GUARD_ANTHROPIC_API_KEY=your-api-key-here
 
+# Anthropic API Base URL (optional)
+# Use for alternative API providers like Z.AI (GLM models)
+# See docs/validation-model.md for Z.AI configuration
+TDD_GUARD_ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic
+
 # Linter type for refactoring phase support (optional)
 # Options: 'eslint', 'golangci-lint' or unset (no linting)
 # See docs/linting.md for detailed setup and configuration

--- a/docs/glm-configuration.md
+++ b/docs/glm-configuration.md
@@ -1,0 +1,89 @@
+# GLM (Z.AI) Configuration
+
+TDD Guard supports Z.AI's GLM models as cost-effective alternatives to Anthropic's Claude models. GLM-4.7 provides an Anthropic-compatible API endpoint, making it a drop-in replacement for TDD validation.
+
+## Why Use GLM?
+
+- Significantly lower token costs compared to Claude models
+- Suitable for TDD validation where Claude-level reasoning may not be necessary
+- Reduces API costs when running frequent validation checks
+
+## Configuration
+
+### Environment Variables
+
+Add these to your `.env` file:
+
+```bash
+VALIDATION_CLIENT=api
+TDD_GUARD_ANTHROPIC_API_KEY=your_zai_api_key
+TDD_GUARD_ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic
+TDD_GUARD_MODEL_VERSION=GLM-4.7
+```
+
+### Available Models
+
+| Model       | Use Case                                |
+| ----------- | --------------------------------------- |
+| GLM-4.7     | Recommended for most validation tasks   |
+| GLM-4.5-Air | Lighter model for faster response times |
+
+## Custom Instructions for GLM
+
+GLM models require different prompting techniques than Claude. The default `instructions.md` is optimized for Claude and may not work optimally with GLM.
+
+### Using GLM-Optimized Instructions
+
+Replace the contents of `.claude/tdd-guard/data/instructions.md` with GLM-specific prompts.
+
+A community-contributed GLM-optimized instructions file is available. See the discussion in [Issue #95](https://github.com/nizos/tdd-guard/issues/95) for the latest version.
+
+### Key Differences
+
+GLM prompts typically need:
+
+- More explicit and structured formatting
+- Clearer step-by-step instructions
+- Different emphasis on validation criteria
+
+## Claude Code Integration
+
+If you're using Claude Code itself with Z.AI as the backend, configure these environment variables in your Claude Code settings (`.claude/settings.json` or `~/.claude/settings.json`):
+
+```json
+{
+  "env": {
+    "ANTHROPIC_AUTH_TOKEN": "your_zai_api_key",
+    "ANTHROPIC_BASE_URL": "https://api.z.ai/api/anthropic",
+    "API_TIMEOUT_MS": "3000000"
+  }
+}
+```
+
+Model mapping for Claude Code:
+
+- `ANTHROPIC_DEFAULT_OPUS_MODEL`: GLM-4.7
+- `ANTHROPIC_DEFAULT_SONNET_MODEL`: GLM-4.7
+- `ANTHROPIC_DEFAULT_HAIKU_MODEL`: GLM-4.5-Air
+
+## Troubleshooting
+
+### API Errors
+
+If you receive authentication errors:
+
+1. Verify your Z.AI API key is correct
+2. Ensure the base URL is exactly `https://api.z.ai/api/anthropic`
+3. Check that `VALIDATION_CLIENT` is set to `api`
+
+### Validation Quality
+
+If GLM validation results seem inconsistent:
+
+1. Use the GLM-optimized `instructions.md` (see above)
+2. Consider using GLM-4.7 instead of GLM-4.5-Air for better accuracy
+3. Review and adjust the custom instructions for your specific use case
+
+## Contributing
+
+If you've developed improved prompts for GLM, consider contributing them back to the community. See [Issue #95](https://github.com/nizos/tdd-guard/issues/95) for ongoing discussion about GLM-optimized instructions.

--- a/docs/validation-model.md
+++ b/docs/validation-model.md
@@ -46,7 +46,7 @@ Get your API key from [console.anthropic.com](https://console.anthropic.com/)
 
 ## Z.AI (GLM 4.7) API
 
-TDD Guard supports Z.AI's GLM models as drop-in replacements for Anthropic's Claude models. Z.AI provides an Anthropic-compatible API endpoint.
+TDD Guard supports Z.AI's GLM models as drop-in replacements for Anthropic's Claude models. Z.AI provides an Anthropic-compatible API endpoint at significantly lower cost.
 
 ```bash
 VALIDATION_CLIENT=api
@@ -55,32 +55,7 @@ TDD_GUARD_ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic
 TDD_GUARD_MODEL_VERSION=GLM-4.7
 ```
 
-**Available GLM Models:**
-
-| Use Case | Model       | Notes                                   |
-| -------- | ----------- | --------------------------------------- |
-| Default  | GLM-4.7     | Recommended for most validation tasks   |
-| Fast     | GLM-4.5-Air | Lighter model for faster response times |
-
-**Claude Code Integration:**
-
-If you're using Claude Code with Z.AI, configure the environment variables in your Claude Code settings:
-
-```json
-{
-  "env": {
-    "ANTHROPIC_AUTH_TOKEN": "your_zai_api_key",
-    "ANTHROPIC_BASE_URL": "https://api.z.ai/api/anthropic",
-    "API_TIMEOUT_MS": "3000000"
-  }
-}
-```
-
-Claude Code model environment variable mapping to GLM models:
-
-- `ANTHROPIC_DEFAULT_OPUS_MODEL`: GLM-4.7
-- `ANTHROPIC_DEFAULT_SONNET_MODEL`: GLM-4.7
-- `ANTHROPIC_DEFAULT_HAIKU_MODEL`: GLM-4.5-Air
+For detailed configuration including custom instructions optimized for GLM, see the [GLM Configuration Guide](glm-configuration.md).
 
 ## Model Selection
 

--- a/docs/validation-model.md
+++ b/docs/validation-model.md
@@ -44,6 +44,44 @@ Get your API key from [console.anthropic.com](https://console.anthropic.com/)
 - Charges separately from your Claude Code subscription ([pricing](https://www.anthropic.com/pricing))
 - We use `TDD_GUARD_ANTHROPIC_API_KEY` (not `ANTHROPIC_API_KEY`) to prevent accidental charges. If you used the regular `ANTHROPIC_API_KEY`, Claude Code might use it for all your normal coding tasks, charging your API account instead of using your subscription.
 
+## Z.AI (GLM 4.7) API
+
+TDD Guard supports Z.AI's GLM models as drop-in replacements for Anthropic's Claude models. Z.AI provides an Anthropic-compatible API endpoint.
+
+```bash
+VALIDATION_CLIENT=api
+TDD_GUARD_ANTHROPIC_API_KEY=your_zai_api_key
+TDD_GUARD_ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic
+TDD_GUARD_MODEL_VERSION=GLM-4.7
+```
+
+**Available GLM Models:**
+
+| Use Case | Model       | Notes                                   |
+| -------- | ----------- | --------------------------------------- |
+| Default  | GLM-4.7     | Recommended for most validation tasks   |
+| Fast     | GLM-4.5-Air | Lighter model for faster response times |
+
+**Claude Code Integration:**
+
+If you're using Claude Code with Z.AI, configure the environment variables in your Claude Code settings:
+
+```json
+{
+  "env": {
+    "ANTHROPIC_AUTH_TOKEN": "your_zai_api_key",
+    "ANTHROPIC_BASE_URL": "https://api.z.ai/api/anthropic",
+    "API_TIMEOUT_MS": "3000000"
+  }
+}
+```
+
+Claude Code model environment variable mapping to GLM models:
+
+- `ANTHROPIC_DEFAULT_OPUS_MODEL`: GLM-4.7
+- `ANTHROPIC_DEFAULT_SONNET_MODEL`: GLM-4.7
+- `ANTHROPIC_DEFAULT_HAIKU_MODEL`: GLM-4.5-Air
+
 ## Model Selection
 
 Configure which Claude model to use for validation (default: `claude-sonnet-4-0`):

--- a/src/config/Config.test.ts
+++ b/src/config/Config.test.ts
@@ -220,6 +220,43 @@ describe('Config', () => {
     })
   })
 
+  describe('anthropicBaseUrl', () => {
+    test('can be set via options', () => {
+      const config = new Config({
+        anthropicBaseUrl: 'https://api.z.ai/api/anthropic',
+      })
+
+      expect(config.anthropicBaseUrl).toBe('https://api.z.ai/api/anthropic')
+    })
+
+    test('options take precedence over env var', () => {
+      process.env.TDD_GUARD_ANTHROPIC_BASE_URL = 'https://env-url.example.com'
+
+      const config = new Config({
+        anthropicBaseUrl: 'https://options-url.example.com',
+      })
+
+      expect(config.anthropicBaseUrl).toBe('https://options-url.example.com')
+    })
+
+    test('falls back to env var when not in options', () => {
+      process.env.TDD_GUARD_ANTHROPIC_BASE_URL =
+        'https://api.z.ai/api/anthropic'
+
+      const config = new Config()
+
+      expect(config.anthropicBaseUrl).toBe('https://api.z.ai/api/anthropic')
+    })
+
+    test('returns undefined when neither options nor env var are set', () => {
+      delete process.env.TDD_GUARD_ANTHROPIC_BASE_URL
+
+      const config = new Config()
+
+      expect(config.anthropicBaseUrl).toBeUndefined()
+    })
+  })
+
   describe('modelType', () => {
     test('can be set via options', () => {
       const config = new Config({ modelType: 'anthropic_api' })

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -23,6 +23,7 @@ export class Config {
   readonly dataDir: string
   readonly useSystemClaude: boolean
   readonly anthropicApiKey: string | undefined
+  readonly anthropicBaseUrl: string | undefined
   readonly modelType: string
   readonly linterType: string | undefined
   readonly modelVersion: string
@@ -34,6 +35,7 @@ export class Config {
     this.dataDir = this.getDataDir(options)
     this.useSystemClaude = this.getUseSystemClaude(options)
     this.anthropicApiKey = this.getAnthropicApiKey(options)
+    this.anthropicBaseUrl = this.getAnthropicBaseUrl(options)
     this.modelType = this.getModelType(options, mode)
     this.linterType = this.getLinterType(options)
     this.modelVersion = this.getModelVersion(options)
@@ -59,6 +61,10 @@ export class Config {
 
   private getAnthropicApiKey(options?: ConfigOptions): string | undefined {
     return options?.anthropicApiKey ?? process.env.TDD_GUARD_ANTHROPIC_API_KEY
+  }
+
+  private getAnthropicBaseUrl(options?: ConfigOptions): string | undefined {
+    return options?.anthropicBaseUrl ?? process.env.TDD_GUARD_ANTHROPIC_BASE_URL
   }
 
   private getModelType(

--- a/src/contracts/types/ConfigOptions.ts
+++ b/src/contracts/types/ConfigOptions.ts
@@ -5,6 +5,7 @@ export type ConfigOptions = {
   projectRoot?: string
   useSystemClaude?: boolean
   anthropicApiKey?: string
+  anthropicBaseUrl?: string
   modelType?: string
   modelVersion?: string
   linterType?: string

--- a/src/validation/models/AnthropicApi.test.ts
+++ b/src/validation/models/AnthropicApi.test.ts
@@ -34,6 +34,17 @@ describe('AnthropicApi', () => {
     expect(sut.wasCreatedWithApiKey(apiKey)).toBe(true)
   })
 
+  test('should create Anthropic client with baseURL from config', () => {
+    const baseUrl = 'https://api.z.ai/api/anthropic'
+    const customSut = createSut(apiKey, modelVersion, baseUrl)
+
+    expect(customSut.wasCreatedWithBaseUrl(baseUrl)).toBe(true)
+  })
+
+  test('should not include baseURL when not configured', () => {
+    expect(sut.wasCreatedWithoutBaseUrl()).toBe(true)
+  })
+
   test('uses model version from config', async () => {
     const call = await sut.askAndGetCall()
     expect(call.model).toBe(modelVersion)
@@ -92,7 +103,7 @@ interface MessageCreateParams {
   messages: Array<{ role: string; content: string }>
 }
 
-function createSut(apiKey?: string, modelVersion?: string) {
+function createSut(apiKey?: string, modelVersion?: string, baseUrl?: string) {
   vi.clearAllMocks()
 
   const mockCreate = vi.fn().mockResolvedValue({
@@ -109,7 +120,11 @@ function createSut(apiKey?: string, modelVersion?: string) {
       }) as unknown as Anthropic
   )
 
-  const config = new Config({ anthropicApiKey: apiKey, modelVersion })
+  const config = new Config({
+    anthropicApiKey: apiKey,
+    modelVersion,
+    anthropicBaseUrl: baseUrl,
+  })
   const client = new AnthropicApi(config)
 
   const mockResponse = (text: string): void => {
@@ -142,6 +157,18 @@ function createSut(apiKey?: string, modelVersion?: string) {
     )
   }
 
+  const wasCreatedWithBaseUrl = (url: string): boolean => {
+    return mockAnthropicConstructor.mock.calls.some(
+      (call) => call[0]?.baseURL === url
+    )
+  }
+
+  const wasCreatedWithoutBaseUrl = (): boolean => {
+    return mockAnthropicConstructor.mock.calls.some(
+      (call) => !('baseURL' in (call[0] ?? {}))
+    )
+  }
+
   const askWithResponse = async (
     responseText: string
   ): Promise<string | undefined> => {
@@ -165,6 +192,8 @@ function createSut(apiKey?: string, modelVersion?: string) {
     getLastCall,
     askAndGetCall,
     wasCreatedWithApiKey,
+    wasCreatedWithBaseUrl,
+    wasCreatedWithoutBaseUrl,
     askWithResponse,
     askWithError,
   }

--- a/src/validation/models/AnthropicApi.ts
+++ b/src/validation/models/AnthropicApi.ts
@@ -11,6 +11,9 @@ export class AnthropicApi implements IModelClient {
     this.config = config ?? new Config()
     this.client = new Anthropic({
       apiKey: this.config.anthropicApiKey,
+      ...(this.config.anthropicBaseUrl && {
+        baseURL: this.config.anthropicBaseUrl,
+      }),
     })
   }
 


### PR DESCRIPTION
Relates to #95

## Summary

Adds infrastructure support for Z.AI's GLM models as drop-in replacements for Anthropic's Claude models. This enables users to configure a custom API base URL to use GLM-4.7 for TDD validation, offering significant cost savings.

This PR provides the foundation and documentation - @SpiGAndromeda is invited to contribute GLM-optimized `instructions.md` content either directly to this PR or as a follow-up.

## Changes

### Code
- Add `anthropicBaseUrl` configuration option to support custom API endpoints
- Update `AnthropicApi` client to pass `baseURL` to the Anthropic SDK when configured
- Add environment variable `TDD_GUARD_ANTHROPIC_BASE_URL` support

### Documentation
- Create dedicated `docs/glm-configuration.md` with detailed Z.AI setup guide
- Update `docs/validation-model.md` to reference the new guide
- Update `.env.example` with base URL configuration

## Configuration

Users can configure Z.AI by setting these environment variables:

```bash
VALIDATION_CLIENT=api
TDD_GUARD_ANTHROPIC_API_KEY=your_zai_api_key
TDD_GUARD_ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic
TDD_GUARD_MODEL_VERSION=GLM-4.7
```

## Testing

- Added 4 unit tests for `anthropicBaseUrl` in Config
- Added 2 unit tests for baseURL passing in AnthropicApi
- All 654 unit tests passing

## Next Steps

The GLM configuration guide includes a placeholder for community-contributed GLM-optimized `instructions.md` content. @SpiGAndromeda mentioned having an adapted prompt that works well with GLM - contributions welcome!
