### PR TITLE
fix(prompt): resolve contradiction blocking without test output

### DIFF
--- a/src/validation/prompts/response.ts
+++ b/src/validation/prompts/response.ts
@@ -25,12 +25,12 @@ When blocking, your reason must:
 - "Over-implementation violation. Test fails with 'Calculator is not defined' but implementation adds both class AND method. Create only an empty class first, then run test again."
 - "Refactoring without passing tests. Test output shows failures. Fix failing tests first, ensure all pass, then refactor."
 - "Premature implementation - implementing without a failing test. Write the test first, run it to see the specific failure, then implement only what's needed to address that failure."
-- "No test output captured. Cannot validate TDD compliance without test results. Run tests using standard commands (npm test, pytest) without output filtering or redirection that may prevent the test reporter from capturing results."
 
 #### Example Approval Reasons:
 - "Adding single test to test file - follows TDD red phase"
 - "Minimal implementation addressing specific test failure"
 - "Refactoring with evidence of passing tests"
+- "No test output available - insufficient information to determine TDD violation, approving changes"
 
 ### Focus
 Remember: You are ONLY evaluating TDD compliance, not:


### PR DESCRIPTION
## Summary

Fix prompt contradiction in `response.ts` that causes incorrect blocking when no test reporter is installed.

- Remove "No test output captured" from example block reasons (contradicts decision value definition)
- Add "No test output available" as example approval reason (aligns with `null` = "insufficient information to determine")

## Problem

The `response.ts` prompt has a contradiction between decision value definitions and example block reasons:

- **Decision values** define `null` as: "Changes follow TDD principles **OR insufficient information to determine**"
- **Example block reasons** include: "No test output captured. Cannot validate TDD compliance without test results."

When no test reporter is installed (custom/browser-based frameworks, Mocha, unittest, etc.), `test.json` is never created. The validator model sees no test section in its prompt, follows the example block reason, and blocks every implementation edit — even after the developer has manually written and verified a failing test.

This makes tdd-guard unusable for any project without a supported reporter.

## Fix

One line removed from example block reasons, one line added to example approval reasons. No code logic changes. Only affects users without a reporter installed — users WITH reporters always have test output and are unaffected.

## Test plan

- [ ] Verify existing tests pass (no behavioral change for reporter users)
- [ ] Manual test: project with no reporter installed → implementation edits should not be blocked when test output is absent
- [ ] Manual test: project WITH reporter → blocking behavior unchanged

## Related

- Roadmap mentions Mocha and unittest support — until those reporters ship, this fix prevents incorrect blocking for those users
- A more robust future enhancement could detect "no reporter installed" in `processHookData.ts` code (before reaching the AI validator) and return a non-blocking informational message