### PR TITLE
fix: sanitize invalid JSON escape sequences in hook data parsing

### DIFF
--- a/src/hooks/parseHookJson.ts
+++ b/src/hooks/parseHookJson.ts
@@ -1,0 +1,14 @@
+function sanitizeInvalidJsonEscapes(input: string): string {
+  return input.replace(
+    /((?:^|[^\\])(?:\\\\)*)\\(?!["\\/bfnrtu])/g,
+    '$1\\\\'
+  )
+}
+
+export function parseHookJson(input: string): unknown {
+  try {
+    return JSON.parse(input)
+  } catch {
+    return JSON.parse(sanitizeInvalidJsonEscapes(input))
+  }
+}

--- a/src/hooks/processHookData.test.ts
+++ b/src/hooks/processHookData.test.ts
@@ -36,8 +36,19 @@ describe('processHookData', () => {
   it('should throw error on invalid JSON', async () => {
     const invalidJson = '{ invalid json'
 
-    // For this test, we need to use processHookData directly since we're testing JSON parsing
     await expect(processHookData(invalidJson)).rejects.toThrow()
+  })
+
+  it('should handle invalid JSON escape sequences from PHP ANSI escape codes', async () => {
+    const storage = new MemoryStorage()
+    // Real-world case: Claude Code sends Edit hook data for a PHP file using \e for ANSI colors.
+    // \e is valid PHP but not a valid JSON escape sequence.
+    const rawInput = '{"hook_event_name":"PreToolUse","tool_name":"Edit","tool_input":{"file_path":"src/Command/OutputCommand.php","old_string":"echo \\"Done\\";","new_string":"echo \\"\\e[32mDone\\e[0m\\";"}}'
+
+    const result = await processHookData(rawInput, { storage })
+
+    expect(result).toHaveProperty('decision')
+    expect(result).toHaveProperty('reason')
   })
 
   it('should save modifications content to storage when tool is Edit', async () => {

--- a/src/hooks/processHookData.ts
+++ b/src/hooks/processHookData.ts
@@ -1,5 +1,6 @@
 import { buildContext } from '../cli/buildContext'
 import { HookData, HookEvents } from './HookEvents'
+import { parseHookJson } from './parseHookJson'
 import { PostToolLintHandler } from './postToolLint'
 import { detectFileType } from './fileTypeDetection'
 import { LinterProvider } from '../providers/LinterProvider'
@@ -50,8 +51,8 @@ export async function processHookData(
   inputData: string,
   deps: ProcessHookDataDeps = {}
 ): Promise<ValidationResult> {
-  const parsedData = JSON.parse(inputData)
-  
+  const parsedData = parseHookJson(inputData) as Record<string, unknown>
+
   // Initialize dependencies
   const storage = deps.storage ?? new FileStorage()
   const guardManager = new GuardManager(storage)

--- a/src/hooks/sessionHandler.ts
+++ b/src/hooks/sessionHandler.ts
@@ -1,5 +1,6 @@
 import { Storage } from '../storage/Storage'
 import { FileStorage } from '../storage/FileStorage'
+import { parseHookJson } from './parseHookJson'
 import { SessionStartSchema } from '../contracts/schemas/toolSchemas'
 import { RULES } from '../validation/prompts/rules'
 
@@ -11,7 +12,7 @@ export class SessionHandler {
   }
 
   async processSessionStart(hookData: string): Promise<void> {
-    const parsedData = JSON.parse(hookData)
+    const parsedData = parseHookJson(hookData)
     const sessionStartResult = SessionStartSchema.safeParse(parsedData)
     
     if (!sessionStartResult.success) {

--- a/src/hooks/userPromptHandler.ts
+++ b/src/hooks/userPromptHandler.ts
@@ -1,4 +1,5 @@
 import { GuardManager } from '../guard/GuardManager'
+import { parseHookJson } from './parseHookJson'
 import { ValidationResult } from '../contracts/types/ValidationResult'
 
 export class UserPromptHandler {
@@ -13,15 +14,19 @@ export class UserPromptHandler {
   }
 
   async processUserCommand(hookData: string): Promise<ValidationResult | undefined> {
-    const data = JSON.parse(hookData)
+    const data = parseHookJson(hookData) as Record<string, unknown>
     
     // Only process UserPromptSubmit events
     if (data.hook_event_name !== 'UserPromptSubmit') {
       return undefined
     }
     
-    const command = data.prompt?.toLowerCase()
-    
+    if (typeof data.prompt !== 'string') {
+      return undefined
+    }
+
+    const command = data.prompt.toLowerCase()
+
     switch (command) {
       case this.GUARD_COMMANDS.ON:
         await this.guardManager.enable()


### PR DESCRIPTION
## Summary

- Fixes `Bad escaped character in JSON` errors when Claude Code sends Edit hook data containing PHP's `\e` (ANSI escape), which is not a valid JSON escape sequence
- Introduces a shared `parseHookJson()` utility that tries `JSON.parse()` first, then falls back to a backslash-counting regex sanitizer that correctly handles edge cases like `\\e`
- Applies the fix to all three raw hook data parsing sites: `processHookData`, `userPromptHandler`, `sessionHandler`

## Context

When editing PHP files that use `\e` for ANSI color codes (e.g. `\e[32m`), Claude Code sends the raw source in the hook JSON's `tool_input.new_string`. Since `\e` is not one of the 8 valid JSON escape sequences (`\"`, `\\`, `\/`, `\b`, `\f`, `\n`, `\r`, `\t`, `\uXXXX`), `JSON.parse()` throws a `SyntaxError` and the hook fails with:

```
Error during validation: Bad escaped character in JSON at position 233
```

The regex uses even/odd backslash counting so that valid JSON like `\\e` (escaped backslash + letter) is left untouched, while invalid `\e` is doubled to `\\e` (literal backslash in parsed output).

## Test plan

- [x] New unit test with real-world PHP `\e` ANSI escape in Edit hook data
- [x] All 625 existing unit tests pass
- [x] Pre-commit hooks (lint, format) pass