### PR TITLE
fix(reporters): handle options object passed by test frameworks

### DIFF
--- a/reporters/storybook/src/StorybookReporter.test.ts
+++ b/reporters/storybook/src/StorybookReporter.test.ts
@@ -31,6 +31,21 @@ describe('StorybookReporter', () => {
     expect(config.dataDir).toBe(expectedDataDir)
   })
 
+  it('uses FileStorage when receiving empty options object', () => {
+    const reporter = new StorybookReporter({})
+    expect(reporter['storage']).toBeInstanceOf(FileStorage)
+  })
+
+  it('uses FileStorage with projectRoot from options object', () => {
+    const rootPath = '/some/project/root'
+    const reporter = new StorybookReporter({ projectRoot: rootPath })
+    expect(reporter['storage']).toBeInstanceOf(FileStorage)
+    const fileStorage = reporter['storage'] as FileStorage
+    const config = fileStorage['config'] as Config
+    const expectedDataDir = join(rootPath, ...DEFAULT_DATA_DIR.split('/'))
+    expect(config.dataDir).toBe(expectedDataDir)
+  })
+
   describe('when collecting story results', () => {
     let storage: MemoryStorage
     let reporter: StorybookReporter

--- a/reporters/storybook/src/StorybookReporter.ts
+++ b/reporters/storybook/src/StorybookReporter.ts
@@ -11,21 +11,31 @@ export class StorybookReporter {
   private readonly storage: Storage
   private readonly collectedTests: Map<string, StoryTest[]> = new Map()
 
-  constructor(storageOrRoot?: Storage | string) {
-    this.storage = this.initializeStorage(storageOrRoot)
+  constructor(input?: Storage | string | Record<string, unknown>) {
+    this.storage = this.initializeStorage(input)
   }
 
-  private initializeStorage(storageOrRoot?: Storage | string): Storage {
-    if (!storageOrRoot) {
-      return new FileStorage()
+  private initializeStorage(
+    input?: Storage | string | Record<string, unknown>
+  ): Storage {
+    if (typeof input === 'string') {
+      return new FileStorage(new Config({ projectRoot: input }))
     }
 
-    if (typeof storageOrRoot === 'string') {
-      const config = new Config({ projectRoot: storageOrRoot })
-      return new FileStorage(config)
+    if (input && typeof input === 'object' && 'saveTest' in input) {
+      return input as Storage
     }
 
-    return storageOrRoot
+    if (
+      input &&
+      typeof input === 'object' &&
+      'projectRoot' in input &&
+      typeof input.projectRoot === 'string'
+    ) {
+      return new FileStorage(new Config({ projectRoot: input.projectRoot }))
+    }
+
+    return new FileStorage()
   }
 
   async onStoryResult(

--- a/reporters/vitest/src/VitestReporter.test.ts
+++ b/reporters/vitest/src/VitestReporter.test.ts
@@ -76,6 +76,21 @@ describe('VitestReporter', () => {
     expect(config.dataDir).toBe(expectedDataDir)
   })
 
+  it('uses FileStorage when receiving empty options object from Vitest', () => {
+    const reporter = new VitestReporter({})
+    expect(reporter['storage']).toBeInstanceOf(FileStorage)
+  })
+
+  it('uses FileStorage with projectRoot from options object', () => {
+    const rootPath = '/some/project/root'
+    const reporter = new VitestReporter({ projectRoot: rootPath })
+    expect(reporter['storage']).toBeInstanceOf(FileStorage)
+    const fileStorage = reporter['storage'] as FileStorage
+    const config = fileStorage['config'] as Config
+    const expectedDataDir = join(rootPath, ...DEFAULT_DATA_DIR.split('/'))
+    expect(config.dataDir).toBe(expectedDataDir)
+  })
+
   describe('when collecting test data', () => {
     beforeEach(async () => {
       sut.reporter.onTestModuleCollected(module)

--- a/reporters/vitest/src/VitestReporter.ts
+++ b/reporters/vitest/src/VitestReporter.ts
@@ -15,11 +15,31 @@ export class VitestReporter implements Reporter {
   private readonly storage: Storage
   private readonly collectedData: ModuleDataMap = new Map()
 
-  constructor(storageOrRoot?: Storage | string) {
-    this.storage =
-      typeof storageOrRoot === 'string'
-        ? new FileStorage(new Config({ projectRoot: storageOrRoot }))
-        : (storageOrRoot ?? new FileStorage())
+  constructor(input?: Storage | string | Record<string, unknown>) {
+    this.storage = this.initializeStorage(input)
+  }
+
+  private initializeStorage(
+    input?: Storage | string | Record<string, unknown>
+  ): Storage {
+    if (typeof input === 'string') {
+      return new FileStorage(new Config({ projectRoot: input }))
+    }
+
+    if (input && typeof input === 'object' && 'saveTest' in input) {
+      return input as Storage
+    }
+
+    if (
+      input &&
+      typeof input === 'object' &&
+      'projectRoot' in input &&
+      typeof input.projectRoot === 'string'
+    ) {
+      return new FileStorage(new Config({ projectRoot: input.projectRoot }))
+    }
+
+    return new FileStorage()
   }
 
   onTestModuleCollected(testModule: TestModule): void {


### PR DESCRIPTION
## Summary

- Fix `VitestReporter` and `StorybookReporter` crashing with `this.storage.saveTest is not a function` when instantiated from string config references
- Constructors now distinguish `Storage` implementations from plain options objects by checking for the `saveTest` method
- Extract `projectRoot` from framework options objects when present

Fixes #103

## Test plan

- [x] Added tests for empty options object `{}` (string config reference)
- [x] Added tests for options object with `projectRoot` (tuple config)
- [x] Existing tests for `Storage` instance and string args still pass
- [x] All 66 reporter tests pass