### PR TITLE
fix(prompt): add refactor phase guidance to validation prompts

### DIFF
--- a/src/validation/prompts/file-types.ts
+++ b/src/validation/prompts/file-types.ts
@@ -21,6 +21,7 @@ export const FILE_TYPES = `## File Type Specific Rules
 - ONLY allowed when relevant tests are passing
 - Moving test setup to beforeEach: Requires passing tests
 - Extracting test helpers: Requires passing tests
+- Removing tests for code that no longer exists: Allowed when tests are passing (this is dead code cleanup, not coverage reduction)
 - Blocked if tests are failing, no test output, or only irrelevant test output
 
 **For test refactoring**: "Relevant tests" are the tests in the file being refactored

--- a/src/validation/prompts/operations/edit.ts
+++ b/src/validation/prompts/operations/edit.ts
@@ -55,4 +55,63 @@ You are reviewing an Edit operation where existing code is being modified. You m
 - Violation: Add \`export class Calculator { add(a, b) { return a + b; } }\`
 - **Reason**: Should only fix "not defined", not implement methods
 
+### Analyzing Refactor Phase Changes
+
+**PREREQUISITE** — Both conditions must be met before allowing refactoring:
+1. The test output must contain tests **for the code being modified** (not just any passing tests). If the test output only covers unrelated modules, block — there is no evidence the changed code is tested.
+2. ALL tests in the output must be passing. If ANY test is failing, block — even if the failing tests seem unrelated to the change.
+
+If either condition is not met, block and instruct the developer to run the relevant tests first.
+
+When both conditions are met, the developer is in the refactor phase.
+Refactoring changes code structure while preserving identical observable behavior.
+
+#### Implementation File Refactoring
+
+When all tests pass, these changes to implementation files are allowed:
+- Restructuring code (extracting methods/functions, renaming, moving code)
+- Removing unused/dead code (methods, functions, classes no longer called)
+- Simplifying logic without changing behavior
+- Adding types, interfaces, or constants to replace magic values
+
+For dead code removal, the relevant tests are those for the code that *remains* in the file. If those tests pass, removing unused code is safe.
+
+#### Test File Refactoring
+
+When all tests pass, these changes to test files are allowed:
+- Restructuring tests (extracting setup to beforeEach, extracting helpers)
+- Removing tests for code that no longer exists (this is dead code cleanup, not coverage reduction)
+- Renaming or reorganizing test descriptions
+
+**Important**: Removing tests during refactoring is valid cleanup when the code they tested has been removed. Coverage of dead code has no value.
+
+#### When refactoring is not the right phase:
+- Adding new behavior or features requires a failing test first (start a new red phase)
+- Changing observable behavior requires a failing test that specifies the new behavior
+- Adding new tests is starting a new TDD cycle (separately allowed under test file rules)
+
+**Example 1 - Valid: extracting a helper method:**
+- Test output: All Calculator tests passing
+- Edit to implementation file: Extracts repeated validation into a private \`validateNumbers()\` method
+- Analysis: Structure changes, behavior preserved → Allow
+
+**Example 2 - Valid: removing dead code from implementation:**
+- Test output: All tests passing
+- Edit to implementation file: Removes \`_find_english_subtitles()\` method that is no longer called
+- Analysis: Unused code removal with passing tests → Allow
+
+**Example 3 - Valid: removing tests for dead code:**
+- Test output: All tests passing
+- Edit to test file: Removes 4 tests for \`_find_english_subtitles()\` which was already removed from the implementation
+- Analysis: Tests for removed code are cleanup, not coverage reduction → Allow
+
+**Example 4 - Invalid: sneaking in new behavior during refactoring:**
+- Test output: All Calculator tests passing
+- Edit to implementation file: Refactors \`add()\` AND adds input validation that throws on NaN
+- Analysis: Input validation is new behavior without a failing test → Block. Refactor the structure first, then write a test for NaN handling.
+
+**Example 5 - Invalid: removing tests while other tests are failing:**
+- Test output: \`adds two numbers\` FAILING with "expected 0 to be 4", \`subtracts two numbers\` passing
+- Edit to test file: Removes the test for \`oldAdd()\`
+- Analysis: Tests are failing — the prerequisite for refactoring is not met. Even though the removed test is for different code, ALL tests must pass before any refactoring (including cleanup). → Block. Fix the failing \`adds two numbers\` test first, then clean up dead tests.
 `

--- a/src/validation/prompts/operations/multi-edit.ts
+++ b/src/validation/prompts/operations/multi-edit.ts
@@ -40,6 +40,38 @@ You are reviewing a MultiEdit operation where multiple edits are being applied t
    - But this doesn't justify multiple new tests
    - Each edit should still follow minimal implementation
 
+### Refactor Phase in MultiEdit
+
+**PREREQUISITE** — Both conditions must be met before allowing refactoring:
+1. The test output must contain tests **for the code being modified** (not just any passing tests). If the test output only covers unrelated modules, block — there is no evidence the changed code is tested.
+2. ALL tests in the output must be passing. If ANY test is failing, block — even if the failing tests seem unrelated to the change.
+
+If either condition is not met, block and instruct the developer to run the relevant tests first.
+
+When both conditions are met, refactoring across multiple edits in the same file is allowed.
+Refactoring changes code structure while preserving identical observable behavior.
+
+#### Implementation File Refactoring
+- Multiple edits that restructure, rename, or clean up code within the same file
+- Removing unused/dead code (methods, functions, classes no longer called)
+- Extracting methods/functions into new locations within the file
+
+For dead code removal, the relevant tests are those for the code that *remains* in the file. If those tests pass, removing unused code is safe.
+
+#### Test File Refactoring
+- Multiple edits that restructure test setup or helpers
+- Removing tests for code that no longer exists (dead code cleanup, not coverage reduction)
+
+#### When refactoring is not the right phase:
+- Adding new behavior or features requires a failing test first (start a new red phase)
+- Changing observable behavior requires a failing test that specifies the new behavior
+
+**Example - Valid refactoring via MultiEdit:**
+- Test output: All Calculator tests passing
+- Edit 1: Renames \`_internalCalc\` method to \`computeResult\`
+- Edit 2: Updates all callers of the renamed method within the same file
+- Analysis: Rename refactoring with passing tests, behavior preserved → Allow
+
 ### Example MultiEdit Analysis
 
 **Edit 1**: Adds empty Calculator class

--- a/test/integration/validator.scenarios.test.ts
+++ b/test/integration/validator.scenarios.test.ts
@@ -314,6 +314,80 @@ describe('Validator', () => {
             })
           })
         })
+
+        describe('Removing dead code and tests', () => {
+          describe('Removing dead code from implementation with passing tests', () => {
+            const oldContent = implementationModifications.withDeadCode
+            const newContent = implementationModifications.withoutDeadCode
+
+            // Should be allowed when tests are passing
+            testOperations(
+              {
+                filePath: implementationFile,
+                oldContent,
+                newContent,
+                todos: todos.refactoring,
+                testResult: testResults.passing,
+                violation: false,
+              },
+              ['Edit', 'MultiEdit']
+            )
+          })
+
+          describe('Removing tests for dead code with passing tests', () => {
+            const oldContent = testModifications.testsIncludingDeadCode
+            const newContent = testModifications.testsWithoutDeadCode
+
+            // Should be allowed when tests are passing
+            testOperations(
+              {
+                filePath: testFile,
+                oldContent,
+                newContent,
+                todos: todos.refactoring,
+                testResult: testResults.passing,
+                violation: false,
+              },
+              ['Edit', 'MultiEdit']
+            )
+          })
+
+          describe('Removing tests while tests are failing', () => {
+            const oldContent = testModifications.testsIncludingDeadCode
+            const newContent = testModifications.testsWithoutDeadCode
+
+            // Should be blocked when tests are failing
+            testOperations(
+              {
+                filePath: testFile,
+                oldContent,
+                newContent,
+                todos: todos.refactoring,
+                testResult: testResults.assertionError,
+                violation: true,
+              },
+              ['Edit', 'MultiEdit']
+            )
+          })
+
+          describe('Removing dead code without test evidence', () => {
+            const oldContent = implementationModifications.withDeadCode
+            const newContent = implementationModifications.withoutDeadCode
+
+            // Should be blocked without test output
+            testOperations(
+              {
+                filePath: implementationFile,
+                oldContent,
+                newContent,
+                todos: todos.refactoring,
+                testResult: testResults.empty,
+                violation: true,
+              },
+              ['Edit', 'MultiEdit']
+            )
+          })
+        })
       })
 
       describe('TDD Violations', () => {

--- a/test/utils/factories/scenarios/languages/python.ts
+++ b/test/utils/factories/scenarios/languages/python.ts
@@ -293,6 +293,30 @@ class TestCalculator:
         assert result == 6
 `,
   },
+  testsIncludingDeadCode: {
+    description: 'tests including dead code',
+    content: `import pytest
+from calculator import Calculator
+
+def test_adds_two_numbers():
+    calculator = Calculator()
+    assert calculator.add(2, 2) == 4
+
+def test_old_adds_two_numbers():
+    calculator = Calculator()
+    assert calculator.old_add(2, 2) == 4
+`,
+  },
+  testsWithoutDeadCode: {
+    description: 'tests without dead code',
+    content: `import pytest
+from calculator import Calculator
+
+def test_adds_two_numbers():
+    calculator = Calculator()
+    assert calculator.add(2, 2) == 4
+`,
+  },
 } as const
 
 // Python implementation modifications
@@ -324,6 +348,23 @@ export const implementationModifications = {
   },
   methodImplementation: {
     description: 'implementing method',
+    content: `class Calculator:
+    def add(self, a: int, b: int) -> int:
+        return a + b
+`,
+  },
+  withDeadCode: {
+    description: 'implementation with dead code',
+    content: `class Calculator:
+    def add(self, a: int, b: int) -> int:
+        return a + b
+
+    def old_add(self, a: int, b: int) -> int:
+        return a + b
+`,
+  },
+  withoutDeadCode: {
+    description: 'implementation without dead code',
     content: `class Calculator:
     def add(self, a: int, b: int) -> int:
         return a + b

--- a/test/utils/factories/scenarios/languages/typescript.ts
+++ b/test/utils/factories/scenarios/languages/typescript.ts
@@ -282,6 +282,39 @@ describe('Calculator', () => {
   })
 `,
   },
+  testsIncludingDeadCode: {
+    description: 'tests including dead code',
+    content: `
+import { describe, test, expect } from 'vitest'
+import { Calculator } from './Calculator'
+
+describe('Calculator', () => {
+  test('add() adds two numbers', () => {
+    const calculator = new Calculator();
+    expect(calculator.add(2, 2)).toBe(4);
+  })
+
+  test('oldAdd() adds two numbers', () => {
+    const calculator = new Calculator();
+    expect(calculator.oldAdd(2, 2)).toBe(4);
+  })
+})
+`,
+  },
+  testsWithoutDeadCode: {
+    description: 'tests without dead code',
+    content: `
+import { describe, test, expect } from 'vitest'
+import { Calculator } from './Calculator'
+
+describe('Calculator', () => {
+  test('add() adds two numbers', () => {
+    const calculator = new Calculator();
+    expect(calculator.add(2, 2)).toBe(4);
+  })
+})
+`,
+  },
 } as const
 
 // Implementation modifications
@@ -319,6 +352,30 @@ export class Calculator {
   },
   methodImplementation: {
     description: 'implementing method',
+    content: `
+export class Calculator {
+  add(a: number, b: number): number {
+    return a + b;
+  }
+}
+`,
+  },
+  withDeadCode: {
+    description: 'implementation with dead code',
+    content: `
+export class Calculator {
+  add(a: number, b: number): number {
+    return a + b;
+  }
+
+  oldAdd(a: number, b: number): number {
+    return a + b;
+  }
+}
+`,
+  },
+  withoutDeadCode: {
+    description: 'implementation without dead code',
     content: `
 export class Calculator {
   add(a: number, b: number): number {

--- a/test/utils/factories/scenarios/types.ts
+++ b/test/utils/factories/scenarios/types.ts
@@ -27,6 +27,8 @@ export interface TestModifications {
   emptyTestContainer: TestData
   emptyTestContainerWithImports: TestData
   refactoredTests: TestData
+  testsIncludingDeadCode: TestData
+  testsWithoutDeadCode: TestData
 }
 
 // Implementation modification types
@@ -38,6 +40,8 @@ export interface ImplementationModifications {
   methodImplementation: TestData
   overEngineered: TestData
   completeClass: TestData
+  withDeadCode: TestData
+  withoutDeadCode: TestData
 }
 
 // Todo state types


### PR DESCRIPTION
## Summary

Adds refactor phase guidance to the TDD validation prompts, fixing the catch-22 where dead code removal was blocked because removing an implementation method required removing its tests first, but removing tests was blocked because no test output justified it.

- Adds "Analyzing Refactor Phase Changes" section to `edit.ts` and `multi-edit.ts` operation prompts
- Adds test removal as valid refactoring in `file-types.ts`
- Adds integration test scenarios for dead code removal (4 scenarios across Edit and MultiEdit)

### Refactor phase prerequisites

The refactor phase requires **two conditions** to be met:
1. Test output must contain tests **for the code being modified** (not just any passing tests)
2. **All** tests in the output must be passing

This prevents both false approvals from irrelevant test output and premature refactoring while tests are failing.

### What's allowed during refactoring

**Implementation files**: restructuring, dead code removal, method extraction, renaming
**Test files**: restructuring, removing tests for code that no longer exists (dead code cleanup)

### Testing

Validated with a 10-scenario x 10-run automated test script (100 total invocations) against the built CLI, covering:

| # | Scenario | Expected | Result |
|---|----------|----------|--------|
| S1 | Remove dead impl method (passing tests) | approve | 10/10 |
| S2 | Remove dead code tests (passing tests) | approve | 10/10 |
| S3 | Remove dead impl (no test output) | block | 10/10 |
| S4 | Remove tests (tests failing) | block | 10/10 |
| S5 | Remove deprecated method (passing tests) | approve | 10/10 |
| S6 | Remove 2 dead test methods (passing tests) | approve | 8/10 |
| S7 | Remove dead impl (irrelevant test output) | block | 10/10 |
| S8 | Extract helper method (passing tests) | approve | 10/10 |
| S9 | Sneak in new method during refactoring | block | 10/10 |
| S10 | Remove dead tests (tests failing) | block | 10/10 |

**98/100 passed.** The 2 failures in S6 are cautious blocks (false negatives), not false approvals — the validator occasionally asks for more evidence before allowing test removal, which is the safe direction.

## Test plan

- [x] `npm run test:unit` — all tests pass (pre-existing GolangciLint failures unrelated)
- [x] `npx tsc --noEmit` — no type errors
- [x] `npm run lint` — no lint errors
- [x] 100 CLI invocations via automated test script — 98/100 pass

Closes #83
Closes #98