### PR TITLE
fix: strip CLAUDECODE env var from SDK client

### DIFF
--- a/src/validation/models/ClaudeAgentSdk.test.ts
+++ b/src/validation/models/ClaudeAgentSdk.test.ts
@@ -99,6 +99,31 @@ describe('ClaudeAgentSdk', () => {
       // Prevents hook trigggers and keeps queries out of project history
       expect(getUsedOptions().cwd).toBe(config.dataDir)
     })
+
+    test('passes env without CLAUDECODE to prevent nested session rejection', async () => {
+      process.env.CLAUDECODE = '1'
+
+      const freshSetup = setupClient(createSDKResultMessage(), config)
+      await freshSetup.client.ask(prompt)
+
+      expect(freshSetup.getUsedOptions().env).toBeDefined()
+      expect(freshSetup.getUsedOptions().env).not.toHaveProperty('CLAUDECODE')
+    })
+
+    test('preserves other environment variables in env', async () => {
+      process.env.CLAUDECODE = '1'
+      process.env.SOME_OTHER_VAR = 'keep-me'
+
+      const freshSetup = setupClient(createSDKResultMessage(), config)
+      await freshSetup.client.ask(prompt)
+
+      expect(freshSetup.getUsedOptions().env).toHaveProperty(
+        'SOME_OTHER_VAR',
+        'keep-me'
+      )
+
+      delete process.env.SOME_OTHER_VAR
+    })
   })
 
   describe('result handling', () => {

--- a/src/validation/models/ClaudeAgentSdk.ts
+++ b/src/validation/models/ClaudeAgentSdk.ts
@@ -49,6 +49,13 @@ export class ClaudeAgentSdk implements IModelClient {
       model: this.config.modelVersion,
       strictMcpConfig: true,
       cwd: this.config.dataDir,
+      env: this.getCleanEnvironment(),
     }
+  }
+
+  private getCleanEnvironment(): Record<string, string | undefined> {
+    const environment = { ...process.env }
+    delete environment.CLAUDECODE
+    return environment
   }
 }


### PR DESCRIPTION
## Summary

- Strip `CLAUDECODE` from the environment passed to the Agent SDK's `query()` to prevent the child Claude process from rejecting as a nested session
- Fixes every default tdd-guard installation (no `VALIDATION_CLIENT` set) when used as a Claude Code hook

Closes #106

## Test plan

- [x] Existing tests pass
- [x] Added tests verifying `CLAUDECODE` is excluded from env
- [x] Added test verifying other env vars are preserved
- [x] Verified manually: tdd-guard hook no longer fails with "Claude Code process exited with code 1"