### PR TITLE
refactor(rspec): add default values to build_example test helper

### DIFF
--- a/reporters/rspec/spec/formatter_spec.rb
+++ b/reporters/rspec/spec/formatter_spec.rb
@@ -149,9 +149,7 @@ RSpec.describe TddGuardRspec::Formatter do
       Dir.mktmpdir do |tmpdir|
         create_formatter_in(tmpdir) do |formatter, storage_dir|
           example = build_example(
-            description: "returns correct value",
-            full_description: "Calculator returns correct value",
-            file_path: "./spec/calculator_spec.rb"
+            description: "returns correct value"
           )
           formatter.example_passed(build_notification(example))
 
@@ -167,7 +165,6 @@ RSpec.describe TddGuardRspec::Formatter do
       Dir.mktmpdir do |tmpdir|
         create_formatter_in(tmpdir) do |formatter, storage_dir|
           example = build_example(
-            description: "works",
             full_description: "Widget works",
             file_path: "./spec/widget_spec.rb"
           )
@@ -185,8 +182,6 @@ RSpec.describe TddGuardRspec::Formatter do
       Dir.mktmpdir do |tmpdir|
         create_formatter_in(tmpdir) do |formatter, storage_dir|
           example = build_example(
-            description: "test",
-            full_description: "test",
             file_path: "./spec/foo_spec.rb"
           )
           formatter.example_passed(build_notification(example))
@@ -201,14 +196,12 @@ RSpec.describe TddGuardRspec::Formatter do
       Dir.mktmpdir do |tmpdir|
         create_formatter_in(tmpdir) do |formatter, storage_dir|
           example = build_example(
-            description: "test",
-            full_description: "test",
             file_path: "spec/bar_spec.rb"
           )
           formatter.example_passed(build_notification(example))
 
           data = run_and_read_json(formatter, storage_dir)
-          expect(all_tests(data)[0]["fullName"]).to eq("spec/bar_spec.rb::test")
+          expect(all_tests(data)[0]["fullName"]).to start_with("spec/bar_spec.rb::")
         end
       end
     end

--- a/reporters/rspec/spec/helpers.rb
+++ b/reporters/rspec/spec/helpers.rb
@@ -4,7 +4,11 @@ require "rspec/core"
 
 module TddGuardRspecHelpers
   # Create a mock RSpec example with the given attributes
-  def build_example(description:, full_description:, file_path:)
+  def build_example(
+    description: "example",
+    full_description: "Example example",
+    file_path: "./spec/example_spec.rb"
+  )
     instance_double(
       RSpec::Core::Example,
       description: description,


### PR DESCRIPTION
## Summary

- Add default values to `build_example` keyword arguments in `spec/helpers.rb`
- Remove unnecessary dummy arguments from tests that only verify a single attribute
- Align path handling assertion to use `start_with` instead of exact match with dummy `full_description`

Closes #117

Follow-up from #109. cc @nizos