### PR TITLE
refactor(rspec): use bundle exec rspec and bump Ruby to 3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2'
+          ruby-version: '3.3'
 
       - name: Install npm dependencies
         run: npm ci

--- a/reporters/rspec/tdd_guard_rspec.gemspec
+++ b/reporters/rspec/tdd_guard_rspec.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.description = "RSpec formatter that captures test results for TDD Guard validation."
   spec.homepage = "https://github.com/nizos/tdd-guard"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.2.0"
+  spec.required_ruby_version = ">= 3.3.0"
 
   spec.files = Dir["lib/**/*.rb"]
   spec.require_paths = ["lib"]

--- a/reporters/test/factories/rspec.ts
+++ b/reporters/test/factories/rspec.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import type { ReporterConfig, TestScenarios } from '../types'
 import { copyTestArtifacts } from './helpers'
 
+// Use hardcoded absolute path for security when available, fall back to PATH for CI environments
 const bundleBinary =
   ['/usr/local/bin/bundle', '/usr/bin/bundle', '/opt/homebrew/bin/bundle'].find(
     existsSync

--- a/reporters/test/factories/rspec.ts
+++ b/reporters/test/factories/rspec.ts
@@ -4,6 +4,11 @@ import { join } from 'node:path'
 import type { ReporterConfig, TestScenarios } from '../types'
 import { copyTestArtifacts } from './helpers'
 
+const bundleBinary =
+  ['/usr/local/bin/bundle', '/usr/bin/bundle', '/opt/homebrew/bin/bundle'].find(
+    existsSync
+  ) ?? 'bundle'
+
 export function createRspecReporter(): ReporterConfig {
   const artifactDir = 'rspec'
   const testScenarios = {
@@ -18,29 +23,31 @@ export function createRspecReporter(): ReporterConfig {
     run: (tempDir, scenario: keyof TestScenarios) => {
       copyTestArtifacts(artifactDir, testScenarios, scenario, tempDir)
 
-      // Symlink vendor/bundle from rspec reporter for gem dependencies
-      const reporterVendorPath = join(__dirname, '../../rspec/vendor')
-      const tempVendorPath = join(tempDir, 'vendor')
-      symlinkSync(reporterVendorPath, tempVendorPath)
-
-      // Run rspec with the TDD Guard formatter
-      const rubyBinary = resolveRubyBinary()
-      const rspecPath = join(
-        __dirname,
-        '../../rspec/vendor/bundle/ruby',
-        getRubyVersion(rubyBinary),
-        'bin/rspec'
+      // Symlink vendor/bundle, Gemfile, and gemspec from rspec reporter
+      const reporterDir = join(__dirname, '../../rspec')
+      symlinkSync(join(reporterDir, 'vendor'), join(tempDir, 'vendor'))
+      symlinkSync(join(reporterDir, 'Gemfile'), join(tempDir, 'Gemfile'))
+      symlinkSync(
+        join(reporterDir, 'Gemfile.lock'),
+        join(tempDir, 'Gemfile.lock')
       )
-      const formatterLibPath = join(__dirname, '../../rspec/lib')
+      symlinkSync(
+        join(reporterDir, 'tdd_guard_rspec.gemspec'),
+        join(tempDir, 'tdd_guard_rspec.gemspec')
+      )
+
+      // Run rspec via bundle exec, letting Bundler handle path resolution
+      const formatterLibPath = join(reporterDir, 'lib')
       const testFile = testScenarios[scenario]
 
       spawnSync(
-        rubyBinary,
+        bundleBinary,
         [
+          'exec',
+          'rspec',
+          testFile,
           '-I',
           formatterLibPath,
-          rspecPath,
-          testFile,
           '--format',
           'TddGuardRspec::Formatter',
         ],
@@ -49,11 +56,7 @@ export function createRspecReporter(): ReporterConfig {
           env: {
             ...process.env,
             TDD_GUARD_PROJECT_ROOT: tempDir,
-            GEM_PATH: join(
-              __dirname,
-              '../../rspec/vendor/bundle/ruby',
-              getRubyVersion(rubyBinary)
-            ),
+            BUNDLE_PATH: 'vendor/bundle',
           },
           stdio: 'pipe',
           encoding: 'utf8',
@@ -61,25 +64,4 @@ export function createRspecReporter(): ReporterConfig {
       )
     },
   }
-}
-
-function resolveRubyBinary(): string {
-  const knownPaths = [
-    '/usr/local/bin/ruby',
-    '/usr/bin/ruby',
-    '/opt/homebrew/bin/ruby',
-  ]
-  return knownPaths.find(existsSync) ?? 'ruby'
-}
-
-function getRubyVersion(rubyBinary: string): string {
-  const result = spawnSync(
-    rubyBinary,
-    ['-e', 'puts RbConfig::CONFIG["ruby_version"]'],
-    {
-      stdio: 'pipe',
-      encoding: 'utf8',
-    }
-  )
-  return result.stdout.trim() || '2.6.0'
 }


### PR DESCRIPTION
## Summary

- Replace `resolveRubyBinary()` and `getRubyVersion()` with `bundle exec rspec` in the test factory, letting Bundler handle gem path resolution
- Bump `required_ruby_version` in gemspec from `>= 3.2.0` to `>= 3.3.0`
- Bump CI Ruby from 3.2 to 3.3 (Ruby 3.2 reached EOL on 2026-03-31)

Closes #118

Follow-up from #109. cc @nizos