### PR TITLE
feat(rspec): handle import/load errors as synthetic test failures

### DIFF
--- a/reporters/rspec/lib/tdd_guard_rspec/formatter.rb
+++ b/reporters/rspec/lib/tdd_guard_rspec/formatter.rb
@@ -12,6 +12,8 @@ module TddGuardRspec
       :example_passed,
       :example_failed,
       :example_pending,
+      :message,
+      :dump_summary,
       :close
 
     DEFAULT_DATA_DIR = ".claude/tdd-guard/data"
@@ -19,6 +21,8 @@ module TddGuardRspec
     def initialize(output)
       super(output)
       @test_results = []
+      @load_errors = []
+      @errors_outside = 0
       @storage_dir = determine_storage_dir
     end
 
@@ -36,7 +40,18 @@ module TddGuardRspec
       record_example(notification.example, "skipped")
     end
 
+    def message(notification)
+      msg = notification.message
+      @load_errors << msg if msg.include?("An error occurred while loading")
+    end
+
+    def dump_summary(notification)
+      @errors_outside = notification.errors_outside_of_examples_count
+    end
+
     def close(_notification)
+      add_load_error_results if @test_results.empty? && @errors_outside > 0
+
       modules_map = {}
       @test_results.each do |test|
         module_path = test["fullName"].split("::").first
@@ -61,6 +76,33 @@ module TddGuardRspec
       }
       test["errors"] = errors if errors
       @test_results << test
+    end
+
+    def add_load_error_results
+      @load_errors.each do |error_msg|
+        file_path = extract_file_path(error_msg)
+        error_name = extract_error_name(error_msg)
+        @test_results << {
+          "name" => error_name,
+          "fullName" => "#{file_path}::#{error_name}",
+          "state" => "failed",
+          "errors" => [{ "message" => error_msg.strip }]
+        }
+      end
+    end
+
+    def extract_file_path(error_msg)
+      match = error_msg.match(/An error occurred while loading (.+)\./)
+      return "unknown" unless match
+
+      match[1].sub(%r{^\./}, "").strip
+    end
+
+    def extract_error_name(error_msg)
+      match = error_msg.match(/^(\w+Error):\s*(.+?)$/m)
+      return "LoadError" unless match
+
+      "#{match[1]}: #{match[2].strip}"
     end
 
     def determine_storage_dir

--- a/reporters/rspec/spec/formatter_spec.rb
+++ b/reporters/rspec/spec/formatter_spec.rb
@@ -298,4 +298,100 @@ RSpec.describe TddGuardRspec::Formatter do
       end
     end
   end
+
+  describe "load error handling" do
+    let(:load_error_message) do
+      <<~MSG.chomp
+        An error occurred while loading ./spec/my_class_spec.rb.
+        Failure/Error: require "my_class"
+
+        LoadError:
+          cannot load such file -- my_class
+        # ./spec/my_class_spec.rb:3:in `<top (required)>'
+      MSG
+    end
+
+    it "captures load errors as synthetic test failures" do
+      Dir.mktmpdir do |tmpdir|
+        create_formatter_in(tmpdir) do |formatter, storage_dir|
+          formatter.message(build_message_notification(load_error_message))
+          formatter.dump_summary(build_summary_notification(errors_outside_of_examples_count: 1))
+
+          data = run_and_read_json(formatter, storage_dir)
+          tests = all_tests(data)
+          expect(tests.length).to eq(1)
+          expect(tests[0]["state"]).to eq("failed")
+        end
+      end
+    end
+
+    it "extracts file path from load error" do
+      Dir.mktmpdir do |tmpdir|
+        create_formatter_in(tmpdir) do |formatter, storage_dir|
+          formatter.message(build_message_notification(load_error_message))
+          formatter.dump_summary(build_summary_notification(errors_outside_of_examples_count: 1))
+
+          data = run_and_read_json(formatter, storage_dir)
+          expect(data["testModules"][0]["moduleId"]).to eq("spec/my_class_spec.rb")
+        end
+      end
+    end
+
+    it "extracts error name from load error" do
+      Dir.mktmpdir do |tmpdir|
+        create_formatter_in(tmpdir) do |formatter, storage_dir|
+          formatter.message(build_message_notification(load_error_message))
+          formatter.dump_summary(build_summary_notification(errors_outside_of_examples_count: 1))
+
+          data = run_and_read_json(formatter, storage_dir)
+          tests = all_tests(data)
+          expect(tests[0]["name"]).to eq("LoadError: cannot load such file -- my_class")
+        end
+      end
+    end
+
+    it "includes full error message in errors array" do
+      Dir.mktmpdir do |tmpdir|
+        create_formatter_in(tmpdir) do |formatter, storage_dir|
+          formatter.message(build_message_notification(load_error_message))
+          formatter.dump_summary(build_summary_notification(errors_outside_of_examples_count: 1))
+
+          data = run_and_read_json(formatter, storage_dir)
+          tests = all_tests(data)
+          expect(tests[0]["errors"][0]["message"]).to include("cannot load such file -- my_class")
+        end
+      end
+    end
+
+    it "does not create synthetic failures when tests ran normally" do
+      Dir.mktmpdir do |tmpdir|
+        create_formatter_in(tmpdir) do |formatter, storage_dir|
+          example = build_example(
+            description: "works",
+            full_description: "MyClass works",
+            file_path: "./spec/my_class_spec.rb"
+          )
+          formatter.example_passed(build_notification(example))
+          formatter.dump_summary(build_summary_notification(errors_outside_of_examples_count: 0))
+
+          data = run_and_read_json(formatter, storage_dir)
+          tests = all_tests(data)
+          expect(tests.length).to eq(1)
+          expect(tests[0]["name"]).to eq("works")
+        end
+      end
+    end
+
+    it "ignores non-load-error messages" do
+      Dir.mktmpdir do |tmpdir|
+        create_formatter_in(tmpdir) do |formatter, storage_dir|
+          formatter.message(build_message_notification("No examples found."))
+          formatter.dump_summary(build_summary_notification(errors_outside_of_examples_count: 0))
+
+          data = run_and_read_json(formatter, storage_dir)
+          expect(data["testModules"]).to eq([])
+        end
+      end
+    end
+  end
 end

--- a/reporters/rspec/spec/helpers.rb
+++ b/reporters/rspec/spec/helpers.rb
@@ -28,4 +28,17 @@ module TddGuardRspecHelpers
     )
     notification
   end
+
+  # Create a mock message notification
+  def build_message_notification(message)
+    instance_double(RSpec::Core::Notifications::MessageNotification, message: message)
+  end
+
+  # Create a mock summary notification
+  def build_summary_notification(errors_outside_of_examples_count:)
+    instance_double(
+      RSpec::Core::Notifications::SummaryNotification,
+      errors_outside_of_examples_count: errors_outside_of_examples_count
+    )
+  end
 end

--- a/reporters/test/reporters.integration.test.ts
+++ b/reporters/test/reporters.integration.test.ts
@@ -118,6 +118,7 @@ describe('Reporters', () => {
         { name: 'go', expected: 'missingImport' },
         { name: 'rust', expected: 'compilation' },
         { name: 'storybook', expected: 'single-import-error.stories' },
+        { name: 'rspec', expected: 'single_import_error_spec.rb' },
       ]
 
       it.each(reporters)('$name reports module path', ({ name, expected }) => {
@@ -194,7 +195,10 @@ describe('Reporters', () => {
         { name: 'go', expected: 'CompilationError' },
         { name: 'rust', expected: 'build' },
         { name: 'storybook', expected: 'play-test' },
-        { name: 'rspec', expected: undefined },
+        {
+          name: 'rspec',
+          expected: 'LoadError: cannot load such file -- non_existent_module',
+        },
       ]
 
       it.each(reporters)(
@@ -320,6 +324,11 @@ describe('Reporters', () => {
         { name: 'go', expected: 'missingImportModule/CompilationError' },
         { name: 'rust', expected: 'compilation::build' },
         { name: 'storybook', expected: 'Calculator Primary play-test' },
+        {
+          name: 'rspec',
+          expected:
+            'single_import_error_spec.rb::LoadError: cannot load such file -- non_existent_module',
+        },
       ]
 
       it.each(reporters)(
@@ -389,6 +398,7 @@ describe('Reporters', () => {
         { name: 'go', expected: 'failed' },
         { name: 'rust', expected: 'failed' },
         { name: 'storybook', expected: 'failed' },
+        { name: 'rspec', expected: 'failed' },
       ]
 
       it.each(reporters)(
@@ -543,6 +553,14 @@ describe('Reporters', () => {
           expected: [
             'Failed to fetch dynamically imported module',
             'single-import-error.stories.js',
+          ],
+        },
+        {
+          name: 'rspec',
+          expected: [
+            'LoadError',
+            'cannot load such file -- non_existent_module',
+            'single_import_error_spec.rb',
           ],
         },
       ]


### PR DESCRIPTION
## Summary

- Register for `message` and `dump_summary` notifications in the RSpec formatter
- Capture load errors (e.g. `LoadError` from failed `require`) as synthetic failed test entries
- Extract file path and error details from the RSpec `message` notification
- Add integration test expectations for RSpec import error scenarios
- Add 6 unit tests covering load error capture, file path extraction, error name extraction, and edge cases

When a `require` fails, Ruby raises before RSpec loads any examples. The formatter previously wrote empty `testModules`, causing the validation agent to block implementation writes. This follows the synthetic test failure pattern described in CONTRIBUTING.md, using the Go and Rust reporters as reference implementations.

Closes #116

Follow-up from #109. cc @nizos