### PR TITLE
docs(rspec): update Ruby requirement and installation instructions

### DIFF
--- a/reporters/rspec/README.md
+++ b/reporters/rspec/README.md
@@ -4,13 +4,15 @@ RSpec formatter that captures test results for TDD Guard validation.
 
 ## Requirements
 
-- Ruby 2.6+
+- Ruby 3.3+
 - RSpec 3.0+
-- [TDD Guard](https://github.com/nizos/tdd-guard) installed globally
+- [TDD Guard](https://github.com/nizos/tdd-guard)
 
 ## Installation
 
-Add to your Gemfile:
+Install TDD Guard by following the instructions in the [TDD Guard repository](https://github.com/nizos/tdd-guard).
+
+Add the reporter to your Gemfile:
 
 ```ruby
 gem "tdd-guard-rspec"


### PR DESCRIPTION
## Summary

- Update minimum Ruby version from 2.6+ to 3.3+ to match the gemspec (`required_ruby_version = ">= 3.3.0"`)
- Replace "installed globally" requirement with a link to the TDD Guard repository
- Add a line directing users to follow the TDD Guard installation instructions before installing the reporter

This keeps the reporter README independent of how TDD Guard is installed, so it does not need updating when the plugin becomes available through the official marketplace.

cc @nizos