### PR TITLE
feat(rspec): add filtered stack field to test errors

### DIFF
--- a/reporters/rspec/lib/tdd_guard_rspec/formatter.rb
+++ b/reporters/rspec/lib/tdd_guard_rspec/formatter.rb
@@ -32,8 +32,10 @@ module TddGuardRspec
 
     def example_failed(notification)
       example = notification.example
-      errors = [{ "message" => notification.exception.message }]
-      record_example(example, "failed", errors)
+      error = { "message" => notification.exception.message }
+      stack = extract_relevant_stack(notification.exception.backtrace)
+      error["stack"] = stack if stack
+      record_example(example, "failed", [error])
     end
 
     def example_pending(notification)
@@ -107,6 +109,15 @@ module TddGuardRspec
       return "LoadError" unless match
 
       "#{match[1]}: #{match[2].strip}"
+    end
+
+    def extract_relevant_stack(backtrace)
+      return nil unless backtrace
+
+      frame = backtrace.find { |line| line.include?("spec/") && !line.include?("/gems/") }
+      return nil unless frame
+
+      frame.sub(%r{^.*/(?=spec/)}, "").sub(%r{^\./}, "")
     end
 
     def determine_storage_dir

--- a/reporters/rspec/spec/formatter_spec.rb
+++ b/reporters/rspec/spec/formatter_spec.rb
@@ -209,6 +209,90 @@ RSpec.describe TddGuardRspec::Formatter do
     end
   end
 
+  describe "stack field" do
+    it "includes first relevant spec line from backtrace" do
+      Dir.mktmpdir do |tmpdir|
+        create_formatter_in(tmpdir) do |formatter, storage_dir|
+          example = build_example(
+            description: "fails",
+            full_description: "MyClass fails",
+            file_path: "./spec/my_class_spec.rb"
+          )
+          backtrace = [
+            "./spec/my_class_spec.rb:5:in `block (2 levels) in <top (required)>'",
+            "/path/to/gems/rspec-core-3.13.0/lib/rspec/core/example.rb:263:in `instance_exec'"
+          ]
+          formatter.example_failed(build_failed_notification(example, message: "error", backtrace: backtrace))
+
+          data = run_and_read_json(formatter, storage_dir)
+          tests = all_tests(data)
+          expect(tests[0]["errors"][0]["stack"]).to eq("spec/my_class_spec.rb:5:in `block (2 levels) in <top (required)>'")
+        end
+      end
+    end
+
+    it "excludes stack when backtrace contains only gem frames" do
+      Dir.mktmpdir do |tmpdir|
+        create_formatter_in(tmpdir) do |formatter, storage_dir|
+          example = build_example(description: "fails", full_description: "MyClass fails")
+          backtrace = [
+            "/path/to/gems/rspec-core-3.13.0/lib/rspec/core/example.rb:263:in `instance_exec'",
+            "/path/to/gems/rspec-core-3.13.0/lib/rspec/core/runner.rb:121:in `run_specs'"
+          ]
+          formatter.example_failed(build_failed_notification(example, message: "error", backtrace: backtrace))
+
+          data = run_and_read_json(formatter, storage_dir)
+          tests = all_tests(data)
+          expect(tests[0]["errors"][0]).not_to have_key("stack")
+        end
+      end
+    end
+
+    it "excludes stack when backtrace is nil" do
+      Dir.mktmpdir do |tmpdir|
+        create_formatter_in(tmpdir) do |formatter, storage_dir|
+          example = build_example(description: "fails", full_description: "MyClass fails")
+          formatter.example_failed(build_failed_notification(example, message: "error"))
+
+          data = run_and_read_json(formatter, storage_dir)
+          tests = all_tests(data)
+          expect(tests[0]["errors"][0]).not_to have_key("stack")
+        end
+      end
+    end
+
+    it "strips leading ./ from stack frame" do
+      Dir.mktmpdir do |tmpdir|
+        create_formatter_in(tmpdir) do |formatter, storage_dir|
+          example = build_example(description: "fails", full_description: "MyClass fails")
+          backtrace = ["./spec/foo_spec.rb:10:in `block'"]
+          formatter.example_failed(build_failed_notification(example, message: "error", backtrace: backtrace))
+
+          data = run_and_read_json(formatter, storage_dir)
+          tests = all_tests(data)
+          expect(tests[0]["errors"][0]["stack"]).to start_with("spec/foo_spec.rb")
+        end
+      end
+    end
+
+    it "extracts spec line from absolute path backtrace" do
+      Dir.mktmpdir do |tmpdir|
+        create_formatter_in(tmpdir) do |formatter, storage_dir|
+          example = build_example(description: "fails", full_description: "MyClass fails")
+          backtrace = [
+            "/path/to/gems/rspec-support-3.13.0/lib/rspec/support.rb:110:in `block'",
+            "/private/tmp/my-project/spec/calc_spec.rb:3:in `block (2 levels) in <top (required)>'"
+          ]
+          formatter.example_failed(build_failed_notification(example, message: "error", backtrace: backtrace))
+
+          data = run_and_read_json(formatter, storage_dir)
+          tests = all_tests(data)
+          expect(tests[0]["errors"][0]["stack"]).to eq("spec/calc_spec.rb:3:in `block (2 levels) in <top (required)>'")
+        end
+      end
+    end
+  end
+
   describe "name extraction" do
     it "uses example.description as name" do
       Dir.mktmpdir do |tmpdir|

--- a/reporters/rspec/spec/helpers.rb
+++ b/reporters/rspec/spec/helpers.rb
@@ -23,8 +23,8 @@ module TddGuardRspecHelpers
   end
 
   # Create a mock failed notification with exception
-  def build_failed_notification(example, message:)
-    exception = instance_double(Exception, message: message)
+  def build_failed_notification(example, message:, backtrace: nil)
+    exception = instance_double(Exception, message: message, backtrace: backtrace)
     notification = instance_double(
       RSpec::Core::Notifications::FailedExampleNotification,
       example: example,


### PR DESCRIPTION
## Summary

- Extract the first relevant spec line from `notification.exception.backtrace` and include it as the optional `stack` field in test errors
- Filter out gem/framework internal frames (lines containing `/gems/`)
- Normalize absolute paths to start from `spec/` (e.g. `/private/tmp/project/spec/calc_spec.rb:3` becomes `spec/calc_spec.rb:3`)
- Add `backtrace` parameter to the test helper with nil default to preserve backward compatibility
- Add 5 unit tests covering relative paths, absolute paths, gem-only backtraces, nil backtraces, and path normalization

The `stack` field is defined as optional in `TestErrorSchema`. Currently Jest, Vitest, and Storybook pass the full stack. This implementation filters to a single relevant line to keep the output concise, following the approach discussed in #126.

Closes #126

cc @nizos