### PR TITLE
feat(rspec): detect interrupted test runs

### DIFF
--- a/reporters/rspec/lib/tdd_guard_rspec/formatter.rb
+++ b/reporters/rspec/lib/tdd_guard_rspec/formatter.rb
@@ -9,6 +9,7 @@ module TddGuardRspec
   # Mirrors the pytest reporter's single-class architecture.
   class Formatter < RSpec::Core::Formatters::BaseFormatter
     RSpec::Core::Formatters.register self,
+      :start,
       :example_passed,
       :example_failed,
       :example_pending,
@@ -23,7 +24,13 @@ module TddGuardRspec
       @test_results = []
       @load_errors = []
       @errors_outside = 0
+      @expected_count = 0
       @storage_dir = determine_storage_dir
+    end
+
+    def start(notification)
+      super
+      @expected_count = notification.count
     end
 
     def example_passed(notification)
@@ -62,9 +69,16 @@ module TddGuardRspec
       end
 
       has_failures = @test_results.any? { |t| t["state"] == "failed" }
+      reason = if has_failures
+                 "failed"
+               elsif @expected_count > 0 && @test_results.length < @expected_count
+                 "interrupted"
+               else
+                 "passed"
+               end
       result = {
         "testModules" => modules_map.values,
-        "reason" => has_failures ? "failed" : "passed"
+        "reason" => reason
       }
 
       FileUtils.mkdir_p(@storage_dir)

--- a/reporters/rspec/spec/formatter_spec.rb
+++ b/reporters/rspec/spec/formatter_spec.rb
@@ -189,6 +189,66 @@ RSpec.describe TddGuardRspec::Formatter do
       end
     end
 
+    it "reports interrupted when fewer results than expected" do
+      Dir.mktmpdir do |tmpdir|
+        create_formatter_in(tmpdir) do |formatter, storage_dir|
+          formatter.start(build_start_notification(count: 5))
+
+          %w[test_one test_two].each do |desc|
+            example = build_example(description: desc, full_description: "MyClass #{desc}")
+            formatter.example_passed(build_notification(example))
+          end
+
+          data = run_and_read_json(formatter, storage_dir)
+          expect(data["reason"]).to eq("interrupted")
+        end
+      end
+    end
+
+    it "reports failed not interrupted when failures exist with fewer results" do
+      Dir.mktmpdir do |tmpdir|
+        create_formatter_in(tmpdir) do |formatter, storage_dir|
+          formatter.start(build_start_notification(count: 5))
+
+          passing = build_example(description: "passes", full_description: "MyClass passes")
+          formatter.example_passed(build_notification(passing))
+
+          failing = build_example(description: "fails", full_description: "MyClass fails")
+          formatter.example_failed(build_failed_notification(failing, message: "expected true"))
+
+          data = run_and_read_json(formatter, storage_dir)
+          expect(data["reason"]).to eq("failed")
+        end
+      end
+    end
+
+    it "reports passed when all expected tests complete" do
+      Dir.mktmpdir do |tmpdir|
+        create_formatter_in(tmpdir) do |formatter, storage_dir|
+          formatter.start(build_start_notification(count: 2))
+
+          %w[test_one test_two].each do |desc|
+            example = build_example(description: desc, full_description: "MyClass #{desc}")
+            formatter.example_passed(build_notification(example))
+          end
+
+          data = run_and_read_json(formatter, storage_dir)
+          expect(data["reason"]).to eq("passed")
+        end
+      end
+    end
+
+    it "reports passed when expected count is zero" do
+      Dir.mktmpdir do |tmpdir|
+        create_formatter_in(tmpdir) do |formatter, storage_dir|
+          formatter.start(build_start_notification(count: 0))
+
+          data = run_and_read_json(formatter, storage_dir)
+          expect(data["reason"]).to eq("passed")
+        end
+      end
+    end
+
     it "reports failed when load errors produce synthetic failures" do
       Dir.mktmpdir do |tmpdir|
         create_formatter_in(tmpdir) do |formatter, storage_dir|

--- a/reporters/rspec/spec/helpers.rb
+++ b/reporters/rspec/spec/helpers.rb
@@ -45,4 +45,12 @@ module TddGuardRspecHelpers
       errors_outside_of_examples_count: errors_outside_of_examples_count
     )
   end
+
+  # Create a mock start notification
+  def build_start_notification(count:)
+    instance_double(
+      RSpec::Core::Notifications::StartNotification,
+      count: count
+    )
+  end
 end


### PR DESCRIPTION
## Summary

- Register for `:start` notification to capture expected example count
- Compare expected count with actual results in `close` to detect interruption
- Check `has_failures` first so `--fail-fast` correctly reports `"failed"`
- Add `build_start_notification` test helper
- Add 4 unit tests: interrupted, fail-fast, all complete, zero count

The `TestResultSchema` defines `reason` as `'passed' | 'failed' | 'interrupted'` but the RSpec reporter only used the first two. When a test run is interrupted (Ctrl+C), it reported `"passed"` if no failures existed. This uses the `:start` notification's example count to detect the mismatch, following the approach discussed in #129.

Closes #129

cc @nizos