### PR TITLE
feat(rspec): add unhandledErrors field to test.json output

### DIFF
--- a/reporters/rspec/lib/tdd_guard_rspec/formatter.rb
+++ b/reporters/rspec/lib/tdd_guard_rspec/formatter.rb
@@ -19,10 +19,14 @@ module TddGuardRspec
 
     DEFAULT_DATA_DIR = ".claude/tdd-guard/data"
 
+    ANSI_ESCAPE = /\e\[[0-9;]*m/
+    CLASS_NAME_LINE = /\A[A-Z(][\w:() ]*:\z/
+
     def initialize(output)
       super(output)
       @test_results = []
       @load_errors = []
+      @unhandled_errors = []
       @errors_outside = 0
       @expected_count = 0
       @storage_dir = determine_storage_dir
@@ -51,7 +55,12 @@ module TddGuardRspec
 
     def message(notification)
       msg = notification.message
-      @load_errors << msg if msg.include?("An error occurred while loading")
+      if msg.include?("An error occurred while loading")
+        @load_errors << msg
+      elsif msg.include?("Failure/Error:")
+        parsed = parse_unhandled_error(msg)
+        @unhandled_errors << parsed if parsed
+      end
     end
 
     def dump_summary(notification)
@@ -80,6 +89,7 @@ module TddGuardRspec
         "testModules" => modules_map.values,
         "reason" => reason
       }
+      result["unhandledErrors"] = @unhandled_errors unless @unhandled_errors.empty?
 
       FileUtils.mkdir_p(@storage_dir)
       File.write(File.join(@storage_dir, "test.json"), JSON.pretty_generate(result))
@@ -132,6 +142,38 @@ module TddGuardRspec
       return nil unless frame
 
       frame.sub(%r{^.*/(?=spec/)}, "").sub(%r{^\./}, "")
+    end
+
+    # Parses a formatted exception string produced by RSpec's internal
+    # ExceptionPresenter (delivered via the :message callback for errors outside
+    # of examples, such as before/after :suite and :context hook failures).
+    #
+    # Returns a Hash with "name", "message", and optional "stack" on success,
+    # or nil if the expected structure cannot be found (safe fallback: the
+    # error is dropped rather than producing malformed output).
+    def parse_unhandled_error(raw)
+      lines = raw.gsub(ANSI_ESCAPE, "").split("\n")
+
+      # The header ends where the backtrace begins (first "# ..." line).
+      # If there is no backtrace at all, the entire message is the header.
+      bt_start = lines.index { |line| line.start_with?("# ") } || lines.length
+
+      header_lines = lines[0...bt_start]
+      class_idx = header_lines.rindex { |line| line =~ CLASS_NAME_LINE }
+      return nil unless class_idx
+
+      name = header_lines[class_idx].chomp(":")
+      message_lines = header_lines[(class_idx + 1)..-1] || []
+      message_body = message_lines.map { |line| line.sub(/\A  /, "") }.join("\n").strip
+      return nil if message_body.empty?
+
+      backtrace_frames = lines[bt_start..-1].to_a.select { |line| line.start_with?("# ") }
+      backtrace_paths = backtrace_frames.map { |line| line.sub(/\A# /, "") }
+      stack = extract_relevant_stack(backtrace_paths)
+
+      result = { "name" => name, "message" => message_body }
+      result["stack"] = stack if stack
+      result
     end
 
     def determine_storage_dir

--- a/reporters/rspec/spec/formatter_spec.rb
+++ b/reporters/rspec/spec/formatter_spec.rb
@@ -596,4 +596,241 @@ RSpec.describe TddGuardRspec::Formatter do
       end
     end
   end
+
+  describe "unhandledErrors field" do
+    # All message strings below are verbatim captures from running real RSpec
+    # 3.13.6 against minimal reproduction cases. They exercise the parser for
+    # every shape the internal ExceptionPresenter is known to produce when
+    # reporting errors outside of examples.
+
+    let(:after_suite_message) do
+      <<~MSG
+
+        An error occurred in an `after(:suite)` hook.
+        Failure/Error: raise RuntimeError, "cleanup failed in after(:suite)"
+
+        RuntimeError:
+          cleanup failed in after(:suite)
+        # ./spec/my_class_spec.rb:4:in `block (2 levels) in <top (required)>'
+      MSG
+    end
+
+    let(:before_suite_message) do
+      <<~MSG
+
+        An error occurred in a `before(:suite)` hook.
+        Failure/Error: raise StandardError, "setup failed in before(:suite)"
+
+        StandardError:
+          setup failed in before(:suite)
+        # ./spec/my_class_spec.rb:4:in `block (2 levels) in <top (required)>'
+      MSG
+    end
+
+    let(:after_context_message) do
+      <<~MSG
+
+        An error occurred in an `after(:context)` hook.
+        Failure/Error: raise RuntimeError, "context cleanup failed"
+
+        RuntimeError:
+          context cleanup failed
+        # ./spec/my_class_spec.rb:3:in `block (2 levels) in <top (required)>'
+      MSG
+    end
+
+    def run_with_message(messages, count: 1)
+      Dir.mktmpdir do |tmpdir|
+        create_formatter_in(tmpdir) do |formatter, storage_dir|
+          Array(messages).each do |msg|
+            formatter.message(build_message_notification(msg))
+          end
+          formatter.dump_summary(build_summary_notification(errors_outside_of_examples_count: count))
+          yield run_and_read_json(formatter, storage_dir)
+        end
+      end
+    end
+
+    it "captures after(:suite) hook failures" do
+      run_with_message(after_suite_message) do |data|
+        expect(data["unhandledErrors"]).to eq([
+          {
+            "name" => "RuntimeError",
+            "message" => "cleanup failed in after(:suite)",
+            "stack" => "spec/my_class_spec.rb:4:in `block (2 levels) in <top (required)>'"
+          }
+        ])
+      end
+    end
+
+    it "captures before(:suite) hook failures" do
+      run_with_message(before_suite_message) do |data|
+        expect(data["unhandledErrors"].first["name"]).to eq("StandardError")
+        expect(data["unhandledErrors"].first["message"]).to eq("setup failed in before(:suite)")
+      end
+    end
+
+    it "captures after(:context) hook failures" do
+      run_with_message(after_context_message) do |data|
+        expect(data["unhandledErrors"].first["name"]).to eq("RuntimeError")
+        expect(data["unhandledErrors"].first["message"]).to eq("context cleanup failed")
+      end
+    end
+
+    it "captures namespaced exception classes" do
+      msg = <<~MSG
+
+        An error occurred in an `after(:suite)` hook.
+        Failure/Error: raise MyApp::DatabaseError, "namespaced error"
+
+        MyApp::DatabaseError:
+          namespaced error
+        # ./spec/my_class_spec.rb:5:in `block (2 levels) in <top (required)>'
+      MSG
+
+      run_with_message(msg) do |data|
+        expect(data["unhandledErrors"].first["name"]).to eq("MyApp::DatabaseError")
+      end
+    end
+
+    it "captures anonymous exception classes" do
+      msg = <<~MSG
+
+        An error occurred in an `after(:suite)` hook.
+        Failure/Error: raise anon, "anonymous class error"
+
+        (anonymous error class):
+          anonymous class error
+        # ./spec/my_class_spec.rb:4:in `block (2 levels) in <top (required)>'
+      MSG
+
+      run_with_message(msg) do |data|
+        expect(data["unhandledErrors"].first["name"]).to eq("(anonymous error class)")
+      end
+    end
+
+    it "captures exception classes without an Error suffix" do
+      msg = <<~MSG
+
+        An error occurred in an `after(:suite)` hook.
+        Failure/Error: raise WeirdName, "no Error suffix"
+
+        WeirdName:
+          no Error suffix
+        # ./spec/my_class_spec.rb:4:in `block (2 levels) in <top (required)>'
+      MSG
+
+      run_with_message(msg) do |data|
+        expect(data["unhandledErrors"].first["name"]).to eq("WeirdName")
+      end
+    end
+
+    it "preserves multi-line exception messages" do
+      msg = <<~MSG
+
+        An error occurred in an `after(:suite)` hook.
+        Failure/Error: raise RuntimeError, "line one\\nline two"
+
+        RuntimeError:
+          line one
+          line two
+        # ./spec/my_class_spec.rb:4:in `block (2 levels) in <top (required)>'
+      MSG
+
+      run_with_message(msg) do |data|
+        expect(data["unhandledErrors"].first["message"]).to eq("line one\nline two")
+      end
+    end
+
+    it "strips ANSI escape codes from the message body" do
+      msg = "\nAn error occurred in an `after(:suite)` hook.\n" \
+            "Failure/Error: raise RuntimeError, \"boom\"\n\n" \
+            "RuntimeError:\n" \
+            "  \e[1;31mboom\e[0m\n" \
+            "# ./spec/my_class_spec.rb:4:in `block (2 levels) in <top (required)>'\n"
+
+      run_with_message(msg) do |data|
+        expect(data["unhandledErrors"].first["message"]).to eq("boom")
+      end
+    end
+
+    it "handles exceptions with empty backtrace" do
+      msg = <<~MSG
+
+        An error occurred in an `after(:suite)` hook.
+        Failure/Error: Unable to find matching line from backtrace
+
+        RuntimeError:
+          error with empty backtrace
+      MSG
+
+      run_with_message(msg) do |data|
+        entry = data["unhandledErrors"].first
+        expect(entry["name"]).to eq("RuntimeError")
+        expect(entry["message"]).to eq("error with empty backtrace")
+        expect(entry).not_to have_key("stack")
+      end
+    end
+
+    it "accumulates multiple unhandled errors in one run" do
+      second_msg = <<~MSG
+
+        An error occurred in an `after(:suite)` hook.
+        Failure/Error: raise StandardError, "second"
+
+        StandardError:
+          second
+        # ./spec/my_class_spec.rb:6:in `block (2 levels) in <top (required)>'
+      MSG
+
+      run_with_message([after_suite_message, second_msg], count: 2) do |data|
+        expect(data["unhandledErrors"].length).to eq(2)
+        expect(data["unhandledErrors"].map { |e| e["name"] }).to eq(["RuntimeError", "StandardError"])
+      end
+    end
+
+    it "skips RSpec-prefixed class names as a safe fallback" do
+      # ExceptionPresenter suppresses the class name line when the class name
+      # matches /RSpec/, leaving us with no reliable way to extract the name.
+      # Parsing must fail gracefully so the error is dropped rather than stored
+      # with corrupt data.
+      msg = "\nAn error occurred in an `after(:suite)` hook.\n" \
+            "Failure/Error: raise RSpecCustom::SomeError, \"rspec prefixed\"\n" \
+            "  rspec prefixed\n" \
+            "# ./spec/my_class_spec.rb:7:in `block (2 levels) in <top (required)>'\n"
+
+      run_with_message(msg) do |data|
+        expect(data).not_to have_key("unhandledErrors")
+      end
+    end
+
+    it "keeps load errors on the existing synthetic-test path" do
+      load_msg = <<~MSG
+        An error occurred while loading ./spec/my_class_spec.rb.
+        Failure/Error: require "my_class"
+
+        LoadError:
+          cannot load such file -- my_class
+        # ./spec/my_class_spec.rb:3:in `<top (required)>'
+      MSG
+
+      run_with_message(load_msg) do |data|
+        expect(data).not_to have_key("unhandledErrors")
+        expect(all_tests(data).length).to eq(1)
+      end
+    end
+
+    it "omits the unhandledErrors key when no unhandled errors occurred" do
+      Dir.mktmpdir do |tmpdir|
+        create_formatter_in(tmpdir) do |formatter, storage_dir|
+          example = build_example(file_path: "./spec/my_class_spec.rb")
+          formatter.example_passed(build_notification(example))
+          formatter.dump_summary(build_summary_notification(errors_outside_of_examples_count: 0))
+
+          data = run_and_read_json(formatter, storage_dir)
+          expect(data).not_to have_key("unhandledErrors")
+        end
+      end
+    end
+  end
 end

--- a/reporters/rspec/spec/unhandled_errors_integration_spec.rb
+++ b/reporters/rspec/spec/unhandled_errors_integration_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "json"
+require "tmpdir"
+require "fileutils"
+require "open3"
+
+# Integration test that runs a real RSpec process end-to-end to verify that the
+# formatter captures unhandled errors correctly.
+#
+# This test exists to detect regressions if a future version of RSpec changes
+# the output format of its internal ExceptionPresenter. The parser in
+# TddGuardRspec::Formatter depends on that format, so a change there will cause
+# this test to fail loudly rather than silently drop data.
+RSpec.describe "unhandled errors integration", :integration do
+  let(:repo_lib) { File.expand_path("../lib", __dir__) }
+
+  def run_rspec(tmpdir, spec_body)
+    spec_dir = File.join(tmpdir, "spec")
+    FileUtils.mkdir_p(spec_dir)
+    File.write(File.join(spec_dir, "hook_spec.rb"), spec_body)
+
+    env = { "TDD_GUARD_PROJECT_ROOT" => tmpdir }
+    cmd = [
+      "bundle", "exec", "rspec",
+      "-I", repo_lib,
+      "--require", "tdd_guard_rspec/formatter",
+      "--format", "TddGuardRspec::Formatter",
+      "spec/hook_spec.rb"
+    ]
+    Open3.capture3(env, *cmd, chdir: tmpdir)
+
+    json_path = File.join(tmpdir, ".claude", "tdd-guard", "data", "test.json")
+    return nil unless File.exist?(json_path)
+    JSON.parse(File.read(json_path))
+  end
+
+  it "captures an after(:suite) hook failure from a real RSpec run" do
+    spec_body = <<~RUBY
+      RSpec.configure do |c|
+        c.after(:suite) { raise RuntimeError, "real integration failure" }
+      end
+
+      RSpec.describe "Integration" do
+        it("passes") { expect(true).to be true }
+      end
+    RUBY
+
+    Dir.mktmpdir do |tmpdir|
+      data = run_rspec(tmpdir, spec_body)
+
+      expect(data).not_to be_nil, "test.json was not written"
+      expect(data).to have_key("unhandledErrors"),
+        "unhandledErrors missing — RSpec's ExceptionPresenter output format may have changed"
+
+      entry = data["unhandledErrors"].first
+      expect(entry["name"]).to eq("RuntimeError")
+      expect(entry["message"]).to eq("real integration failure")
+    end
+  end
+end

--- a/reporters/rspec/spec/unhandled_errors_integration_spec.rb
+++ b/reporters/rspec/spec/unhandled_errors_integration_spec.rb
@@ -13,7 +13,7 @@ require "open3"
 # the output format of its internal ExceptionPresenter. The parser in
 # TddGuardRspec::Formatter depends on that format, so a change there will cause
 # this test to fail loudly rather than silently drop data.
-RSpec.describe "unhandled errors integration", :integration do
+RSpec.describe "unhandled errors integration" do
   let(:repo_lib) { File.expand_path("../lib", __dir__) }
 
   def run_rspec(tmpdir, spec_body)


### PR DESCRIPTION
## Summary

- Parse the formatted exception string from RSpec's internal `ExceptionPresenter` (delivered via the `:message` callback) to populate the `unhandledErrors` field in `test.json`
- Route LoadError messages to the existing synthetic-test path first, preserving current behavior
- Strip ANSI escape codes before parsing so `SyntaxError#detailed_message` output is handled
- Add 14 unit tests covering hook failures, namespaced/anonymous/non-`Error`-suffixed classes, multi-line messages, empty backtraces, and multiple errors in one run
- Add an integration test that runs real RSpec end-to-end to detect `ExceptionPresenter` format regressions in future versions, per discussion in #130

`dump_summary` only exposes `errors_outside_of_examples_count` as an integer; the exception objects themselves are not available on any formatter callback. The `:message` callback does deliver the full exception details, but only as a pre-formatted string. The parser targets that shape and extracts `name`, `message`, and optional `stack` for `UnhandledErrorSchema`.

When the shape cannot be recognized — for example, when a class name contains `RSpec` and the presenter suppresses the class line (`exception_presenter.rb:207`) — the error is dropped rather than serialized with corrupt data. This is the safe fallback nizos suggested in #130 so future format changes degrade gracefully instead of producing broken output.

Closes #130

cc @nizos