### PR TITLE
feat(linters): add RuboCop linter integration for Ruby projects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
           ruby-version: '3.3'
 
       - name: Install RuboCop
-        run: gem install rubocop
+        run: gem install rubocop -v 1.86.0
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,14 @@ jobs:
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.3.1
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
+      - name: Install RuboCop
+        run: gem install rubocop
+
       - name: Install dependencies
         run: npm ci
 

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -1,6 +1,7 @@
 # Linting and Refactoring Support
 
-TDD Guard can optionally check code quality during the refactoring phase (when tests are green) using ESLint.
+TDD Guard can optionally check code quality during the refactoring phase (when tests are green).
+The following linters are supported: ESLint (JavaScript/TypeScript), golangci-lint (Go), and RuboCop (Ruby).
 When issues are detected, the coding agent will be prompted to fix them.
 
 ## Why Use Refactoring Support?
@@ -20,19 +21,29 @@ The refactoring support helps by:
 
 ## Setup
 
-1. **Install ESLint** in your project:
+1. **Install a supported linter** in your project:
+
+   For JavaScript/TypeScript (ESLint):
 
    ```bash
    npm install --save-dev eslint@latest
    ```
 
+   For Go (golangci-lint): see the [golangci-lint installation guide](https://golangci-lint.run/welcome/install/).
+
+   For Ruby (RuboCop):
+
+   ```bash
+   gem install rubocop
+   ```
+
 2. **Enable linting** by setting the environment variable:
 
    ```bash
-   LINTER_TYPE=eslint
+   LINTER_TYPE=eslint          # for ESLint
+   LINTER_TYPE=golangci-lint   # for golangci-lint
+   LINTER_TYPE=rubocop         # for RuboCop
    ```
-
-   Note: Currently only ESLint is supported. Additional linters may be added in the future.
 
 3. **Configure the PostToolUse hook**
 
@@ -74,11 +85,11 @@ The refactoring support helps by:
 When enabled:
 
 1. After any file modification (Edit, MultiEdit, Write)
-2. TDD Guard runs ESLint on modified files
+2. TDD Guard runs the configured linter on modified files
 3. If issues are found, the coding agent receives a notification
 4. The agent will then fix the identified issues
 
-Without `LINTER_TYPE=eslint`, TDD Guard skips all linting operations.
+Without `LINTER_TYPE` set, TDD Guard skips all linting operations.
 
 **Tip**: Configure ESLint with complexity rules (e.g., `complexity`, `max-depth`) and the SonarJS plugin to encourage meaningful refactoring.
 These rules help identify code that could benefit from simplification during the green phase.
@@ -105,5 +116,12 @@ module.exports = {
 
 1. Verify ESLint is installed: `npm list eslint`
 2. Check that `LINTER_TYPE=eslint` is set in your `.env` file
+3. Ensure the PostToolUse hook is configured
+4. Restart your Claude session after making changes
+
+### RuboCop Not Running
+
+1. Verify RuboCop is installed: `rubocop --version`
+2. Check that `LINTER_TYPE=rubocop` is set in your `.env` file
 3. Ensure the PostToolUse hook is configured
 4. Restart your Claude session after making changes

--- a/src/contracts/schemas/lintSchemas.test.ts
+++ b/src/contracts/schemas/lintSchemas.test.ts
@@ -473,9 +473,9 @@ describe('RuboCopResultSchema', () => {
       expectedSuccess: true,
     },
     {
-      description: 'without required files',
+      description: 'valid result without files (undefined)',
       result: testData.ruboCopResultWithout(['files']),
-      expectedSuccess: false,
+      expectedSuccess: true,
     },
     {
       description: 'with non-array files',

--- a/src/contracts/schemas/lintSchemas.test.ts
+++ b/src/contracts/schemas/lintSchemas.test.ts
@@ -8,6 +8,10 @@ import {
   GolangciLintPositionSchema,
   GolangciLintIssueSchema,
   GolangciLintResultSchema,
+  RuboCopLocationSchema,
+  RuboCopOffenseSchema,
+  RuboCopFileSchema,
+  RuboCopResultSchema,
 } from './lintSchemas'
 import { testData } from '@testUtils'
 
@@ -342,6 +346,147 @@ describe('GolangciLintResultSchema', () => {
     },
   ])('$description', ({ result, expectedSuccess }) => {
     const parseResult = GolangciLintResultSchema.safeParse(result)
+    expect(parseResult.success).toBe(expectedSuccess)
+  })
+})
+
+describe('RuboCopLocationSchema', () => {
+  test.each([
+    {
+      description: 'valid location with all fields',
+      location: testData.ruboCopLocation(),
+      expectedSuccess: true,
+    },
+    {
+      description: 'without required line',
+      location: testData.ruboCopLocationWithout(['line']),
+      expectedSuccess: false,
+    },
+    {
+      description: 'without required column',
+      location: testData.ruboCopLocationWithout(['column']),
+      expectedSuccess: false,
+    },
+    {
+      description: 'with invalid line type',
+      location: {
+        ...testData.ruboCopLocation(),
+        line: '10',
+      },
+      expectedSuccess: false,
+    },
+  ])('$description', ({ location, expectedSuccess }) => {
+    const result = RuboCopLocationSchema.safeParse(location)
+    expect(result.success).toBe(expectedSuccess)
+  })
+})
+
+describe('RuboCopOffenseSchema', () => {
+  test.each([
+    {
+      description: 'valid offense with all fields',
+      offense: testData.ruboCopOffense(),
+      expectedSuccess: true,
+    },
+    {
+      description: 'without required severity',
+      offense: testData.ruboCopOffenseWithout(['severity']),
+      expectedSuccess: false,
+    },
+    {
+      description: 'without required message',
+      offense: testData.ruboCopOffenseWithout(['message']),
+      expectedSuccess: false,
+    },
+    {
+      description: 'without required cop_name',
+      offense: testData.ruboCopOffenseWithout(['cop_name']),
+      expectedSuccess: false,
+    },
+    {
+      description: 'without required location',
+      offense: testData.ruboCopOffenseWithout(['location']),
+      expectedSuccess: false,
+    },
+    {
+      description: 'with invalid location structure',
+      offense: {
+        ...testData.ruboCopOffense(),
+        location: {
+          ...testData.ruboCopLocation(),
+          line: 'invalid',
+        },
+      },
+      expectedSuccess: false,
+    },
+  ])('$description', ({ offense, expectedSuccess }) => {
+    const result = RuboCopOffenseSchema.safeParse(offense)
+    expect(result.success).toBe(expectedSuccess)
+  })
+})
+
+describe('RuboCopFileSchema', () => {
+  test.each([
+    {
+      description: 'valid file with offenses array',
+      file: testData.ruboCopFile(),
+      expectedSuccess: true,
+    },
+    {
+      description: 'valid file with empty offenses array',
+      file: testData.ruboCopFile({ offenses: [] }),
+      expectedSuccess: true,
+    },
+    {
+      description: 'without required path',
+      file: testData.ruboCopFileWithout(['path']),
+      expectedSuccess: false,
+    },
+    {
+      description: 'without required offenses',
+      file: testData.ruboCopFileWithout(['offenses']),
+      expectedSuccess: false,
+    },
+    {
+      description: 'with malformed offense in offenses array',
+      file: testData.ruboCopFile({
+        offenses: [testData.ruboCopOffenseWithout(['message'])],
+      }),
+      expectedSuccess: false,
+    },
+  ])('$description', ({ file, expectedSuccess }) => {
+    const result = RuboCopFileSchema.safeParse(file)
+    expect(result.success).toBe(expectedSuccess)
+  })
+})
+
+describe('RuboCopResultSchema', () => {
+  test.each([
+    {
+      description: 'valid result with files array',
+      result: testData.ruboCopResult(),
+      expectedSuccess: true,
+    },
+    {
+      description: 'valid result with empty files array',
+      result: testData.ruboCopResult({ files: [] }),
+      expectedSuccess: true,
+    },
+    {
+      description: 'without required files',
+      result: testData.ruboCopResultWithout(['files']),
+      expectedSuccess: false,
+    },
+    {
+      description: 'with non-array files',
+      result: {
+        ...testData.ruboCopResult(),
+        files: 'not-an-array',
+      },
+      expectedSuccess: false,
+    },
+  ])('$description', ({ result, expectedSuccess }) => {
+    const parseResult = RuboCopResultSchema.safeParse(result)
     expect(parseResult.success).toBe(expectedSuccess)
   })
 })

--- a/src/contracts/schemas/lintSchemas.ts
+++ b/src/contracts/schemas/lintSchemas.ts
@@ -48,7 +48,7 @@ export const RuboCopFileSchema = z.object({
 })
 
 export const RuboCopResultSchema = z.object({
-  files: z.array(RuboCopFileSchema),
+  files: z.array(RuboCopFileSchema).optional(),
 })
 
 export const LintIssueSchema = z.object({

--- a/src/contracts/schemas/lintSchemas.ts
+++ b/src/contracts/schemas/lintSchemas.ts
@@ -30,6 +30,27 @@ export const GolangciLintResultSchema = z.object({
   Issues: z.array(GolangciLintIssueSchema).optional(),
 })
 
+export const RuboCopLocationSchema = z.object({
+  line: z.number(),
+  column: z.number(),
+})
+
+export const RuboCopOffenseSchema = z.object({
+  severity: z.string(),
+  message: z.string(),
+  cop_name: z.string(),
+  location: RuboCopLocationSchema,
+})
+
+export const RuboCopFileSchema = z.object({
+  path: z.string(),
+  offenses: z.array(RuboCopOffenseSchema),
+})
+
+export const RuboCopResultSchema = z.object({
+  files: z.array(RuboCopFileSchema),
+})
+
 export const LintIssueSchema = z.object({
   file: z.string(),
   line: z.number(),
@@ -56,6 +77,10 @@ export type ESLintResult = z.infer<typeof ESLintResultSchema>
 export type GolangciLintPosition = z.infer<typeof GolangciLintPositionSchema>
 export type GolangciLintIssue = z.infer<typeof GolangciLintIssueSchema>
 export type GolangciLintResult = z.infer<typeof GolangciLintResultSchema>
+export type RuboCopLocation = z.infer<typeof RuboCopLocationSchema>
+export type RuboCopOffense = z.infer<typeof RuboCopOffenseSchema>
+export type RuboCopFile = z.infer<typeof RuboCopFileSchema>
+export type RuboCopResult = z.infer<typeof RuboCopResultSchema>
 export type LintData = z.infer<typeof LintDataSchema>
 export type LintIssue = z.infer<typeof LintIssueSchema>
 export type LintResult = z.infer<typeof LintResultSchema>

--- a/src/linters/rubocop/RuboCop.test.ts
+++ b/src/linters/rubocop/RuboCop.test.ts
@@ -1,0 +1,134 @@
+import { describe, test, expect, beforeEach } from 'vitest'
+import { RuboCop } from './RuboCop'
+import { join } from 'path'
+import { LintResult } from '../../contracts/schemas/lintSchemas'
+import { hasRules, issuesFromFile } from '../../../test/utils/assertions'
+
+describe('RuboCop', () => {
+  let linter: RuboCop
+
+  beforeEach(() => {
+    linter = new RuboCop()
+  })
+
+  test('can be instantiated', () => {
+    expect(linter).toBeDefined()
+  })
+
+  test('implements Linter interface with lint method', async () => {
+    const result = await linter.lint([])
+
+    expect(result).toBeDefined()
+    expect(result.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
+  })
+
+  test('returns the file paths that were passed in', async () => {
+    const filePaths = ['src/file1.rb', 'src/file2.rb']
+    const result = await linter.lint(filePaths)
+
+    expect(result.files).toEqual(filePaths)
+  })
+
+  describe('with single file', () => {
+    let result: LintResult
+
+    beforeEach(async () => {
+      result = await linter.lint(['src/file.rb'])
+    })
+
+    test('returns empty issues array', () => {
+      expect(result.issues).toEqual([])
+    })
+
+    test('returns zero error count', () => {
+      expect(result.errorCount).toBe(0)
+    })
+
+    test('returns zero warning count', () => {
+      expect(result.warningCount).toBe(0)
+    })
+  })
+
+  describe('with files containing special characters', () => {
+    test.each([
+      ['spaces', 'src/my file with spaces.rb'],
+      ['quotes', 'src/file"with"quotes.rb'],
+      ['semicolons', 'src/file;name.rb'],
+      ['backticks', 'src/file`with`backticks.rb'],
+      ['dollar signs', 'src/file$with$dollar.rb'],
+      ['pipes', 'src/file|with|pipes.rb'],
+      ['ampersands', 'src/file&with&ampersands.rb'],
+      ['parentheses', 'src/file(with)parentheses.rb'],
+      ['command injection attempt', 'file.rb"; cat /etc/passwd; echo "'],
+      ['newlines', 'src/file\nwith\nnewlines.rb'],
+      ['tabs', 'src/file\twith\ttabs.rb'],
+    ])('handles file paths with %s correctly', async (_, filePath) => {
+      const result = await linter.lint([filePath])
+
+      expect(result.files).toEqual([filePath])
+      expect(result.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
+    })
+
+    test.each([
+      ['spaces', '/path with spaces/.rubocop.yml'],
+      ['quotes', '/path"with"quotes/.rubocop.yml'],
+      ['special chars', '/path;with&special|chars/.rubocop.yml'],
+    ])('handles config paths with %s correctly', async (_, configPath) => {
+      const result = await linter.lint(['src/file.rb'], configPath)
+
+      expect(result.files).toEqual(['src/file.rb'])
+      expect(result.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
+    })
+  })
+
+  describe('linter.lint with artifact files', () => {
+    const artifactsDir = join(process.cwd(), 'test', 'artifacts', 'ruby')
+    const configPath = join(artifactsDir, '.rubocop.yml')
+
+    test('detects issues in file with lint problems', async () => {
+      const filePath = join(artifactsDir, 'file-with-issues.rb')
+      const result = await linter.lint([filePath], configPath)
+
+      expect(result.issues.length).toBeGreaterThan(0)
+
+      // Check for specific cops
+      const expectedRules = [
+        'Lint/UselessAssignment',
+        'Style/StringLiterals',
+        'Metrics/ParameterLists',
+      ]
+      const ruleResults = hasRules(result.issues, expectedRules)
+
+      ruleResults.forEach((ruleExists) => {
+        expect(ruleExists).toBe(true)
+      })
+    })
+
+    test('finds no issues in clean file', async () => {
+      const filePath = join(artifactsDir, 'file-without-issues.rb')
+      const result = await linter.lint([filePath], configPath)
+
+      expect(result.issues.length).toBe(0)
+      expect(result.errorCount).toBe(0)
+      expect(result.warningCount).toBe(0)
+    })
+
+    test('processes multiple files correctly', async () => {
+      const files = [
+        join(artifactsDir, 'file-with-issues.rb'),
+        join(artifactsDir, 'file-without-issues.rb'),
+      ]
+      const result = await linter.lint(files, configPath)
+
+      expect(result.files).toEqual(files)
+      expect(result.issues.length).toBeGreaterThan(0)
+
+      // Issues should only be from the file with issues
+      const cleanFileIssues = issuesFromFile(
+        result.issues,
+        'file-without-issues.rb'
+      )
+      expect(cleanFileIssues.length).toBe(0)
+    })
+  })
+})

--- a/src/linters/rubocop/RuboCop.ts
+++ b/src/linters/rubocop/RuboCop.ts
@@ -1,0 +1,86 @@
+import {
+  LintResult,
+  LintIssue,
+  RuboCopResult,
+  RuboCopFile,
+  RuboCopOffense,
+} from '../../contracts/schemas/lintSchemas'
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import { Linter } from '../Linter'
+
+const execFileAsync = promisify(execFile)
+
+export class RuboCop implements Linter {
+  async lint(filePaths: string[], configPath?: string): Promise<LintResult> {
+    const timestamp = new Date().toISOString()
+    const args = buildArgs(filePaths, configPath)
+
+    try {
+      const { stdout } = await execFileAsync('rubocop', args)
+      return createLintData(timestamp, filePaths, parseResults(stdout))
+    } catch (error) {
+      if (!isExecError(error)) throw error
+
+      return createLintData(timestamp, filePaths, parseResults(error.stdout))
+    }
+  }
+}
+
+// Helper functions
+const buildArgs = (files: string[], configPath?: string): string[] => {
+  const args = [...files, '--format', 'json']
+  if (configPath) {
+    args.push('--config', configPath)
+  }
+  return args
+}
+
+const isExecError = (error: unknown): error is Error & { stdout?: string } =>
+  error !== null && typeof error === 'object' && 'stdout' in error
+
+const parseResults = (stdout?: string): RuboCopFile[] => {
+  try {
+    const parsed: RuboCopResult = JSON.parse(stdout ?? '{"files":[]}')
+    return parsed.files
+  } catch {
+    return []
+  }
+}
+
+const createLintData = (
+  timestamp: string,
+  files: string[],
+  results: RuboCopFile[]
+): LintResult => {
+  const issues = extractIssues(results)
+  return {
+    timestamp,
+    files,
+    issues,
+    errorCount: countBySeverity(issues, 'error'),
+    warningCount: countBySeverity(issues, 'warning'),
+  }
+}
+
+const extractIssues = (results: RuboCopFile[]): LintIssue[] =>
+  results.flatMap((file) => file.offenses.map(toIssue(file.path)))
+
+const toIssue =
+  (filePath: string) =>
+  (offense: RuboCopOffense): LintIssue => ({
+    file: filePath,
+    line: offense.location.line,
+    column: offense.location.column,
+    severity: mapSeverity(offense.severity),
+    message: offense.message,
+    rule: offense.cop_name,
+  })
+
+const mapSeverity = (severity: string): 'error' | 'warning' =>
+  severity === 'error' || severity === 'fatal' ? 'error' : 'warning'
+
+const countBySeverity = (
+  issues: LintIssue[],
+  severity: 'error' | 'warning'
+): number => issues.filter((i) => i.severity === severity).length

--- a/src/linters/rubocop/RuboCop.ts
+++ b/src/linters/rubocop/RuboCop.ts
@@ -42,7 +42,7 @@ const isExecError = (error: unknown): error is Error & { stdout?: string } =>
 const parseResults = (stdout?: string): RuboCopFile[] => {
   try {
     const parsed: RuboCopResult = JSON.parse(stdout ?? '{"files":[]}')
-    return parsed.files
+    return parsed.files ?? []
   } catch {
     return []
   }

--- a/src/providers/LinterProvider.test.ts
+++ b/src/providers/LinterProvider.test.ts
@@ -3,6 +3,7 @@ import { LinterProvider } from './LinterProvider'
 import { Config } from '../config/Config'
 import { ESLint } from '../linters/eslint/ESLint'
 import { GolangciLint } from '../linters/golangci/GolangciLint'
+import { RuboCop } from '../linters/rubocop/RuboCop'
 
 describe('LinterProvider', () => {
   test('returns ESLint when config linterType is eslint', () => {
@@ -21,6 +22,15 @@ describe('LinterProvider', () => {
     const linter = provider.getLinter(config)
 
     expect(linter).toBeInstanceOf(GolangciLint)
+  })
+
+  test('returns RuboCop when config linterType is rubocop', () => {
+    const config = new Config({ linterType: 'rubocop' })
+
+    const provider = new LinterProvider()
+    const linter = provider.getLinter(config)
+
+    expect(linter).toBeInstanceOf(RuboCop)
   })
 
   test('returns null when config linterType is explicitly undefined', () => {

--- a/src/providers/LinterProvider.ts
+++ b/src/providers/LinterProvider.ts
@@ -2,6 +2,7 @@ import { Linter } from '../linters/Linter'
 import { Config } from '../config/Config'
 import { ESLint } from '../linters/eslint/ESLint'
 import { GolangciLint } from '../linters/golangci/GolangciLint'
+import { RuboCop } from '../linters/rubocop/RuboCop'
 
 export class LinterProvider {
   getLinter(config?: Config): Linter | null {
@@ -12,6 +13,8 @@ export class LinterProvider {
         return new ESLint()
       case 'golangci-lint':
         return new GolangciLint()
+      case 'rubocop':
+        return new RuboCop()
       case undefined:
       default:
         return null

--- a/test/artifacts/ruby/.rubocop.yml
+++ b/test/artifacts/ruby/.rubocop.yml
@@ -1,0 +1,12 @@
+AllCops:
+  NewCops: disable
+
+Naming/FileName:
+  Enabled: false
+
+Style/StringLiterals:
+  Enabled: true
+  EnforcedStyle: single_quotes
+
+Lint/UselessAssignment:
+  Enabled: true

--- a/test/artifacts/ruby/file-with-issues.rb
+++ b/test/artifacts/ruby/file-with-issues.rb
@@ -1,0 +1,6 @@
+# This file has intentional lint issues for testing
+x = 1
+def foo(a, b, c, d, e, f)
+  puts "hello"
+  return a + b
+end

--- a/test/artifacts/ruby/file-without-issues.rb
+++ b/test/artifacts/ruby/file-without-issues.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+def greet(name)
+  puts "Hello, #{name}"
+end
+
+greet('World')

--- a/test/utils/factories/lintFactory.ts
+++ b/test/utils/factories/lintFactory.ts
@@ -11,6 +11,10 @@ import type {
   GolangciLintPosition,
   GolangciLintIssue,
   GolangciLintResult,
+  RuboCopLocation,
+  RuboCopOffense,
+  RuboCopFile,
+  RuboCopResult,
 } from '../../../src/contracts/schemas/lintSchemas'
 import { omit } from './helpers'
 
@@ -348,5 +352,128 @@ export const golangciLintResultWithout = <K extends keyof GolangciLintResult>(
   params?: Partial<GolangciLintResult>
 ): Omit<GolangciLintResult, K> => {
   const fullResult = golangciLintResult(params)
+  return omit(fullResult, keys)
+}
+
+/**
+ * Creates a RuboCop location object
+ * @param params - Optional parameters for the location
+ */
+export const ruboCopLocation = (
+  params?: Partial<RuboCopLocation>
+): RuboCopLocation => {
+  const defaults: RuboCopLocation = {
+    line: 10,
+    column: 5,
+  }
+
+  return {
+    ...defaults,
+    ...params,
+  }
+}
+
+/**
+ * Creates a RuboCop location object with specified properties omitted
+ * @param keys - Array of property keys to omit
+ * @param params - Optional parameters for the location
+ */
+export const ruboCopLocationWithout = <K extends keyof RuboCopLocation>(
+  keys: K[],
+  params?: Partial<RuboCopLocation>
+): Omit<RuboCopLocation, K> => {
+  const fullLocation = ruboCopLocation(params)
+  return omit(fullLocation, keys)
+}
+
+/**
+ * Creates a RuboCop offense object
+ * @param params - Optional parameters for the offense
+ */
+export const ruboCopOffense = (
+  params?: Partial<RuboCopOffense>
+): RuboCopOffense => {
+  const defaults: RuboCopOffense = {
+    severity: 'convention',
+    message: 'Use 2 (not 4) spaces for indentation.',
+    cop_name: 'Layout/IndentationWidth',
+    location: ruboCopLocation(),
+  }
+
+  return {
+    ...defaults,
+    ...params,
+  }
+}
+
+/**
+ * Creates a RuboCop offense object with specified properties omitted
+ * @param keys - Array of property keys to omit
+ * @param params - Optional parameters for the offense
+ */
+export const ruboCopOffenseWithout = <K extends keyof RuboCopOffense>(
+  keys: K[],
+  params?: Partial<RuboCopOffense>
+): Omit<RuboCopOffense, K> => {
+  const fullOffense = ruboCopOffense(params)
+  return omit(fullOffense, keys)
+}
+
+/**
+ * Creates a RuboCop file object
+ * @param params - Optional parameters for the file
+ */
+export const ruboCopFile = (params?: Partial<RuboCopFile>): RuboCopFile => {
+  const defaults: RuboCopFile = {
+    path: '/src/example.rb',
+    offenses: [ruboCopOffense()],
+  }
+
+  return {
+    ...defaults,
+    ...params,
+  }
+}
+
+/**
+ * Creates a RuboCop file object with specified properties omitted
+ * @param keys - Array of property keys to omit
+ * @param params - Optional parameters for the file
+ */
+export const ruboCopFileWithout = <K extends keyof RuboCopFile>(
+  keys: K[],
+  params?: Partial<RuboCopFile>
+): Omit<RuboCopFile, K> => {
+  const fullFile = ruboCopFile(params)
+  return omit(fullFile, keys)
+}
+
+/**
+ * Creates a RuboCop result object
+ * @param params - Optional parameters for the result
+ */
+export const ruboCopResult = (
+  params?: Partial<RuboCopResult>
+): RuboCopResult => {
+  const defaults: RuboCopResult = {
+    files: [ruboCopFile()],
+  }
+
+  return {
+    ...defaults,
+    ...params,
+  }
+}
+
+/**
+ * Creates a RuboCop result object with specified properties omitted
+ * @param keys - Array of property keys to omit
+ * @param params - Optional parameters for the result
+ */
+export const ruboCopResultWithout = <K extends keyof RuboCopResult>(
+  keys: K[],
+  params?: Partial<RuboCopResult>
+): Omit<RuboCopResult, K> => {
+  const fullResult = ruboCopResult(params)
   return omit(fullResult, keys)
 }

--- a/test/utils/index.ts
+++ b/test/utils/index.ts
@@ -117,6 +117,14 @@ export const testData = {
   golangciLintIssueWithout: lintFactory.golangciLintIssueWithout,
   golangciLintResult: lintFactory.golangciLintResult,
   golangciLintResultWithout: lintFactory.golangciLintResultWithout,
+  ruboCopLocation: lintFactory.ruboCopLocation,
+  ruboCopLocationWithout: lintFactory.ruboCopLocationWithout,
+  ruboCopOffense: lintFactory.ruboCopOffense,
+  ruboCopOffenseWithout: lintFactory.ruboCopOffenseWithout,
+  ruboCopFile: lintFactory.ruboCopFile,
+  ruboCopFileWithout: lintFactory.ruboCopFileWithout,
+  ruboCopResult: lintFactory.ruboCopResult,
+  ruboCopResultWithout: lintFactory.ruboCopResultWithout,
 
   // UserPromptSubmit factories
   userPromptSubmit: userPromptSubmitFactory.userPromptSubmit,


### PR DESCRIPTION
## Summary

- Add `RuboCop` linter class that runs `rubocop --format json` and maps offenses to `LintIssue`
- Register `rubocop` case in `LinterProvider` so `LINTER_TYPE=rubocop` activates it
- Add Zod schemas for RuboCop JSON output (`RuboCopLocationSchema`, `RuboCopOffenseSchema`, `RuboCopFileSchema`, `RuboCopResultSchema`)
- Add test factories and schema tests following the ESLint and GolangciLint patterns
- Add artifacts-based tests with `test/artifacts/ruby/` (`file-with-issues.rb`, `file-without-issues.rb`, `.rubocop.yml`)
- Add `ruby/setup-ruby` and `gem install rubocop` to the `unit-tests` CI job
- Update `docs/linting.md` to document the new linter alongside ESLint

RuboCop defines 6 severity levels (`info`, `refactor`, `convention`, `warning`, `error`, `fatal`) but `LintIssueSchema` only accepts `'error' | 'warning'`. The mapping follows the approach discussed in #131: `error`/`fatal` → `'error'`, everything else → `'warning'`. Only stdout is parsed because RuboCop writes cop configuration warnings to stderr.

The `.rubocop.yml` disables `Naming/FileName` so the hyphenated fixture filenames (`file-with-issues.rb`) do not themselves trigger offenses in the clean artifact test.

Closes #131

cc @nizos