### PR TITLE
refactor(minitest): use bundle exec in test factory to match CI Ruby version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,12 @@ jobs:
           bundle config set --local path vendor/bundle
           bundle install
 
+      - name: Install Minitest reporter dependencies
+        working-directory: reporters/minitest
+        run: |
+          bundle config set --local path vendor/bundle
+          bundle install
+
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/reporters/test/factories/minitest.ts
+++ b/reporters/test/factories/minitest.ts
@@ -1,14 +1,14 @@
 import { spawnSync } from 'node:child_process'
-import { existsSync } from 'node:fs'
+import { existsSync, symlinkSync } from 'node:fs'
 import { join } from 'node:path'
 import type { ReporterConfig, TestScenarios } from '../types'
 import { copyTestArtifacts } from './helpers'
 
 // Use hardcoded absolute path for security when available, fall back to PATH for CI environments
-const rubyBinary =
-  ['/usr/local/bin/ruby', '/usr/bin/ruby', '/opt/homebrew/bin/ruby'].find(
+const bundleBinary =
+  ['/usr/local/bin/bundle', '/usr/bin/bundle', '/opt/homebrew/bin/bundle'].find(
     existsSync
-  ) ?? 'ruby'
+  ) ?? 'bundle'
 
 export function createMinitestReporter(): ReporterConfig {
   const artifactDir = 'minitest'
@@ -24,18 +24,37 @@ export function createMinitestReporter(): ReporterConfig {
     run: (tempDir, scenario: keyof TestScenarios) => {
       copyTestArtifacts(artifactDir, testScenarios, scenario, tempDir)
 
-      const reporterLibPath = join(__dirname, '../../minitest/lib')
+      // Symlink vendor/bundle, Gemfile, and gemspec from minitest reporter
+      const reporterDir = join(__dirname, '../../minitest')
+      symlinkSync(join(reporterDir, 'vendor'), join(tempDir, 'vendor'))
+      symlinkSync(join(reporterDir, 'Gemfile'), join(tempDir, 'Gemfile'))
+      symlinkSync(
+        join(reporterDir, 'Gemfile.lock'),
+        join(tempDir, 'Gemfile.lock')
+      )
+      symlinkSync(
+        join(reporterDir, 'tdd_guard_minitest.gemspec'),
+        join(tempDir, 'tdd_guard_minitest.gemspec')
+      )
+
+      // Run minitest via bundle exec, letting Bundler handle path resolution
+      const reporterLibPath = join(reporterDir, 'lib')
       const testFile = testScenarios[scenario]
 
-      spawnSync(rubyBinary, ['-I', reporterLibPath, testFile], {
-        cwd: tempDir,
-        env: {
-          ...process.env,
-          TDD_GUARD_PROJECT_ROOT: tempDir,
-        },
-        stdio: 'pipe',
-        encoding: 'utf8',
-      })
+      spawnSync(
+        bundleBinary,
+        ['exec', 'ruby', '-I', reporterLibPath, testFile],
+        {
+          cwd: tempDir,
+          env: {
+            ...process.env,
+            TDD_GUARD_PROJECT_ROOT: tempDir,
+            BUNDLE_PATH: 'vendor/bundle',
+          },
+          stdio: 'pipe',
+          encoding: 'utf8',
+        }
+      )
     },
   }
 }


### PR DESCRIPTION
## Summary

- Replace hardcoded Ruby binary resolution with `bundle exec ruby`, matching the pattern applied to the RSpec factory in 93f4eb9
- Symlink `vendor/`, `Gemfile`, `Gemfile.lock`, and gemspec into the test temp directory so Bundler can resolve dependencies
- Add Minitest reporter `bundle install` step to CI workflow

Closes #141

cc @nizos