### PR TITLE
fix: strip ANTHROPIC_API_KEY from validation subprocess environment

### DIFF
--- a/src/validation/models/ClaudeAgentSdk.test.ts
+++ b/src/validation/models/ClaudeAgentSdk.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
 import { ClaudeAgentSdk } from './ClaudeAgentSdk'
 import { Config } from '../../config/Config'
 import { IModelClient } from '../../contracts/types/ModelClient'
@@ -48,6 +48,12 @@ describe('ClaudeAgentSdk', () => {
 
     beforeEach(async () => {
       await client.ask(prompt)
+    })
+
+    afterEach(() => {
+      delete process.env.CLAUDECODE
+      delete process.env.SOME_OTHER_VAR
+      delete process.env.ANTHROPIC_API_KEY
     })
 
     test('calls queryFn with correct prompt', async () => {
@@ -121,8 +127,6 @@ describe('ClaudeAgentSdk', () => {
         'SOME_OTHER_VAR',
         'keep-me'
       )
-
-      delete process.env.SOME_OTHER_VAR
     })
 
     test('strips ANTHROPIC_API_KEY from env to prevent subscription bypass', async () => {
@@ -135,8 +139,6 @@ describe('ClaudeAgentSdk', () => {
       expect(freshSetup.getUsedOptions().env).not.toHaveProperty(
         'ANTHROPIC_API_KEY'
       )
-
-      delete process.env.ANTHROPIC_API_KEY
     })
   })
 

--- a/src/validation/models/ClaudeAgentSdk.test.ts
+++ b/src/validation/models/ClaudeAgentSdk.test.ts
@@ -124,6 +124,20 @@ describe('ClaudeAgentSdk', () => {
 
       delete process.env.SOME_OTHER_VAR
     })
+
+    test('strips ANTHROPIC_API_KEY from env to prevent subscription bypass', async () => {
+      process.env.ANTHROPIC_API_KEY = 'sk-dummy-key'
+
+      const freshSetup = setupClient(createSDKResultMessage(), config)
+      await freshSetup.client.ask(prompt)
+
+      expect(freshSetup.getUsedOptions().env).toBeDefined()
+      expect(freshSetup.getUsedOptions().env).not.toHaveProperty(
+        'ANTHROPIC_API_KEY'
+      )
+
+      delete process.env.ANTHROPIC_API_KEY
+    })
   })
 
   describe('result handling', () => {

--- a/src/validation/models/ClaudeAgentSdk.ts
+++ b/src/validation/models/ClaudeAgentSdk.ts
@@ -56,6 +56,7 @@ export class ClaudeAgentSdk implements IModelClient {
   private getCleanEnvironment(): Record<string, string | undefined> {
     const environment = { ...process.env }
     delete environment.CLAUDECODE
+    delete environment.ANTHROPIC_API_KEY
     return environment
   }
 }

--- a/src/validation/models/ClaudeCli.test.ts
+++ b/src/validation/models/ClaudeCli.test.ts
@@ -168,6 +168,31 @@ describe('ClaudeCli', () => {
     })
   })
 
+  describe('environment isolation', () => {
+    test('strips ANTHROPIC_API_KEY from subprocess environment', async () => {
+      process.env.ANTHROPIC_API_KEY = 'sk-dummy-key'
+
+      const call = await sut.askAndGetCall()
+
+      expect(call.options.env).toBeDefined()
+      expect(call.options.env).not.toHaveProperty('ANTHROPIC_API_KEY')
+
+      delete process.env.ANTHROPIC_API_KEY
+    })
+
+    test('preserves other environment variables when stripping ANTHROPIC_API_KEY', async () => {
+      process.env.ANTHROPIC_API_KEY = 'sk-dummy-key'
+      process.env.SOME_OTHER_VAR = 'keep-me'
+
+      const call = await sut.askAndGetCall()
+
+      expect(call.options.env).toHaveProperty('SOME_OTHER_VAR', 'keep-me')
+
+      delete process.env.ANTHROPIC_API_KEY
+      delete process.env.SOME_OTHER_VAR
+    })
+  })
+
   describe('security', () => {
     test('uses execFileSync with system claude when useSystemClaude is true', async () => {
       const localSut = createSut({ useSystemClaude: true })

--- a/src/validation/models/ClaudeCli.test.ts
+++ b/src/validation/models/ClaudeCli.test.ts
@@ -169,6 +169,11 @@ describe('ClaudeCli', () => {
   })
 
   describe('environment isolation', () => {
+    afterEach(() => {
+      delete process.env.ANTHROPIC_API_KEY
+      delete process.env.SOME_OTHER_VAR
+    })
+
     test('strips ANTHROPIC_API_KEY from subprocess environment', async () => {
       process.env.ANTHROPIC_API_KEY = 'sk-dummy-key'
 
@@ -176,8 +181,6 @@ describe('ClaudeCli', () => {
 
       expect(call.options.env).toBeDefined()
       expect(call.options.env).not.toHaveProperty('ANTHROPIC_API_KEY')
-
-      delete process.env.ANTHROPIC_API_KEY
     })
 
     test('preserves other environment variables when stripping ANTHROPIC_API_KEY', async () => {
@@ -187,9 +190,6 @@ describe('ClaudeCli', () => {
       const call = await sut.askAndGetCall()
 
       expect(call.options.env).toHaveProperty('SOME_OTHER_VAR', 'keep-me')
-
-      delete process.env.ANTHROPIC_API_KEY
-      delete process.env.SOME_OTHER_VAR
     })
   })
 

--- a/src/validation/models/ClaudeCli.ts
+++ b/src/validation/models/ClaudeCli.ts
@@ -33,11 +33,15 @@ export class ClaudeCli implements IModelClient {
       mkdirSync(claudeDir, { recursive: true })
     }
 
+    const env = { ...process.env }
+    delete env.ANTHROPIC_API_KEY
+
     const output = execFileSync(claudeBinary, args, {
       encoding: 'utf-8',
       timeout: 60000,
       input: prompt,
       cwd: claudeDir,
+      env,
       shell: process.platform === 'win32',
     })
 


### PR DESCRIPTION
## Summary

- Extends `ClaudeAgentSdk.getCleanEnvironment()` to also strip `ANTHROPIC_API_KEY` alongside the existing `CLAUDECODE` removal
- Passes a cleaned `env` to `ClaudeCli`'s `execFileSync` call, preventing the key from leaking into the subprocess
- Adds tests for both clients verifying the key is stripped while other env vars are preserved

## Context

When `ANTHROPIC_API_KEY` is set in the shell, the Claude Agent SDK and CLI inherit it and use it for billing instead of the user's Claude subscription. If that key belongs to a disabled or expired organization, validation fails with a cryptic JSON parse error:

```
Error: Error during validation: Unexpected token 'C', "Credit bal"... is not valid JSON
```

CI/CD users on `VALIDATION_CLIENT=api` are unaffected — they use `TDD_GUARD_ANTHROPIC_API_KEY` exclusively.

Fixes #139

Considered this fix since the user is after specifically unsetting the API key for tdd-guard: https://github.com/nizos/tdd-guard/issues/139#issuecomment-4221456464

## Test plan

- [ ] `npx vitest run src/validation/models/ClaudeCli.test.ts src/validation/models/ClaudeAgentSdk.test.ts` passes
- [ ] Verify with dummy key: `ANTHROPIC_API_KEY=sk-dummy npm run test:unit`
- [ ] `npm run lint:check` and `npm run format:check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)