### PR TITLE
feat(minitest): handle load errors as synthetic test failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ eggs/
 .eggs/
 lib/
 !reporters/rspec/lib/
+!reporters/minitest/lib/
 lib64/
 parts/
 sdist/

--- a/reporters/minitest/README.md
+++ b/reporters/minitest/README.md
@@ -26,13 +26,27 @@ gem install tdd-guard-minitest
 
 ## Usage
 
-Run Minitest with the TDD Guard reporter:
+Require the autorun entry point before your test files. This registers the reporter as a Minitest plugin and also installs an `at_exit` hook that captures load errors (for example, a new test file that `require`s an implementation file that doesn't exist yet) as synthetic failed tests, so TDD Guard can see that a test tried to run.
+
+Run a single test file directly:
 
 ```bash
-ruby -r tdd_guard_minitest/reporter test/my_test.rb
+ruby -rtdd_guard_minitest/autorun test/my_test.rb
 ```
 
-The reporter registers itself as a Minitest plugin and activates automatically when required.
+For Rails or Rake projects, require it from `test/test_helper.rb`:
+
+```ruby
+require "tdd_guard_minitest/autorun"
+```
+
+Or pass it to your `Rake::TestTask` so every `rake test` invocation loads it first:
+
+```ruby
+Rake::TestTask.new do |t|
+  t.ruby_opts << "-rtdd_guard_minitest/autorun"
+end
+```
 
 ## Configuration
 

--- a/reporters/minitest/lib/tdd_guard_minitest/autorun.rb
+++ b/reporters/minitest/lib/tdd_guard_minitest/autorun.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Entry point used to guarantee that the tdd-guard-minitest reporter is in
+# place before the user's test file is loaded. Loading Minitest::Autorun
+# here registers Minitest's own at_exit hook, and the at_exit block below
+# is registered *after* it, which means it fires *before* Minitest's hook
+# in LIFO order. That lets us intercept unhandled exceptions raised while
+# loading the user's test file (typically a LoadError from a missing
+# require) and write a synthetic failed test to test.json so the
+# validation agent can see that a test tried to run and failed.
+#
+# Usage:
+#
+#   ruby -rtdd_guard_minitest/autorun path/to/test.rb
+#
+# or from test/test_helper.rb:
+#
+#   require "tdd_guard_minitest/autorun"
+
+require "minitest/autorun"
+require "tdd_guard_minitest/reporter"
+
+at_exit do
+  exc = $!
+  next if exc.nil?
+  next if exc.is_a?(SystemExit)
+
+  TddGuardMinitest::Reporter.handle_load_error(exc)
+end

--- a/reporters/minitest/lib/tdd_guard_minitest/reporter.rb
+++ b/reporters/minitest/lib/tdd_guard_minitest/reporter.rb
@@ -16,6 +16,27 @@ module TddGuardMinitest
       @storage_dir = determine_storage_dir
     end
 
+    # Writes a synthetic failed-test JSON for an exception raised before
+    # Minitest had a chance to run (typically a LoadError from a missing
+    # require at the top of a test file). Called from lib/tdd_guard_minitest/
+    # autorun.rb's at_exit hook when $! is set.
+    #
+    # Mirrors the structure of the RSpec reporter's load-error handling
+    # (see reporters/rspec/lib/tdd_guard_rspec/formatter.rb): inject a
+    # synthetic entry into @test_results, then write the JSON. Skips if
+    # test.json already exists to avoid clobbering real results written
+    # by any earlier at_exit block.
+    def self.handle_load_error(exception)
+      new(StringIO.new).handle_load_error(exception)
+    end
+
+    def handle_load_error(exception)
+      return if File.exist?(File.join(@storage_dir, "test.json"))
+
+      add_load_error(exception)
+      write_load_error_result
+    end
+
     def record(result)
       state = if result.skipped?
                 "skipped"
@@ -89,6 +110,58 @@ module TddGuardMinitest
       expanded = File.expand_path(root)
       cwd = Dir.pwd
       cwd == expanded || cwd.start_with?("#{expanded}/")
+    end
+
+    # Injects a synthetic failed test entry derived from an exception raised
+    # before Minitest could run. Mirrors RSpec's `add_load_error_results`
+    # (reporters/rspec/lib/tdd_guard_rspec/formatter.rb).
+    def add_load_error(exception)
+      frame = first_user_frame(exception.backtrace)
+      file_path = frame ? frame.split(":", 2).first.to_s.sub(%r{^\./}, "") : "unknown"
+      name = "#{exception.class}: #{exception.message.lines.first.to_s.strip}"
+      message = build_load_error_message(exception, frame)
+
+      @test_results << {
+        "name" => name,
+        "fullName" => "#{file_path}::#{name}",
+        "state" => "failed",
+        "errors" => [{ "message" => message }]
+      }
+    end
+
+    def first_user_frame(backtrace)
+      return nil unless backtrace
+
+      backtrace.find do |line|
+        (line.include?("_test.rb") || line.include?("_spec.rb")) && !line.include?("/gems/")
+      end
+    end
+
+    def build_load_error_message(exception, frame)
+      header = "#{exception.class}: #{exception.message}"
+      return header unless frame
+
+      "#{header}\n    #{frame.sub(%r{^\./}, '')}"
+    end
+
+    # Writes the synthetic load-error JSON. Inlined here (rather than reusing
+    # the public `report` method) so that this PR does not need to change
+    # `report`'s signature -- the `reason` field is added by a separate issue.
+    def write_load_error_result
+      modules_map = {}
+      @test_results.each do |test|
+        module_path = test["fullName"].split("::").first
+        modules_map[module_path] ||= { "moduleId" => module_path, "tests" => [] }
+        modules_map[module_path]["tests"] << test
+      end
+
+      result = {
+        "testModules" => modules_map.values,
+        "reason" => "failed"
+      }
+
+      FileUtils.mkdir_p(@storage_dir)
+      File.write(File.join(@storage_dir, "test.json"), JSON.pretty_generate(result))
     end
   end
 end

--- a/reporters/minitest/spec/load_error_integration_spec.rb
+++ b/reporters/minitest/spec/load_error_integration_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "json"
+require "tmpdir"
+require "fileutils"
+require "open3"
+
+# Integration test that runs a real Ruby process end-to-end to verify that
+# the at_exit hook in lib/tdd_guard_minitest/autorun.rb captures load errors
+# correctly.
+#
+# This test exists to detect regressions if Minitest or Ruby changes the
+# ordering semantics of at_exit blocks or the visibility of $! during
+# process teardown. A failure here signals that the load-error capture
+# path is broken end-to-end, even if the unit specs still pass.
+RSpec.describe "load error integration" do
+  let(:repo_lib) { File.expand_path("../lib", __dir__) }
+
+  def run_minitest(tmpdir, test_body)
+    test_dir = File.join(tmpdir, "test")
+    FileUtils.mkdir_p(test_dir)
+    File.write(File.join(test_dir, "load_error_test.rb"), test_body)
+
+    env = { "TDD_GUARD_PROJECT_ROOT" => tmpdir }
+    cmd = [
+      "bundle", "exec", "ruby",
+      "-I", repo_lib,
+      "-rtdd_guard_minitest/autorun",
+      "test/load_error_test.rb"
+    ]
+    Open3.capture3(env, *cmd, chdir: tmpdir)
+
+    json_path = File.join(tmpdir, ".claude", "tdd-guard", "data", "test.json")
+    return nil unless File.exist?(json_path)
+    JSON.parse(File.read(json_path))
+  end
+
+  it "captures a LoadError from a real ruby process" do
+    test_body = <<~RUBY
+      require "non_existent_module"
+      require "minitest/autorun"
+
+      class CalculatorTest < Minitest::Test
+        def test_should_add
+          assert_equal 5, 2 + 3
+        end
+      end
+    RUBY
+
+    Dir.mktmpdir do |tmpdir|
+      data = run_minitest(tmpdir, test_body)
+
+      expect(data).not_to be_nil,
+        "test.json was not written -- at_exit ordering or $! visibility may have changed"
+      expect(data["reason"]).to eq("failed")
+      expect(data["testModules"].length).to eq(1)
+
+      test = data["testModules"][0]["tests"][0]
+      expect(test["state"]).to eq("failed")
+      expect(test["name"]).to include("LoadError")
+      expect(test["name"]).to include("non_existent_module")
+      expect(test["errors"][0]["message"]).to include("load_error_test.rb")
+    end
+  end
+
+  it "does not write a synthetic failure when the test file loads cleanly" do
+    test_body = <<~RUBY
+      require "minitest/autorun"
+
+      class CalculatorTest < Minitest::Test
+        def test_should_add
+          assert_equal 5, 2 + 3
+        end
+      end
+    RUBY
+
+    Dir.mktmpdir do |tmpdir|
+      data = run_minitest(tmpdir, test_body)
+
+      expect(data).not_to be_nil, "test.json should still be written via the normal report path"
+      tests = data["testModules"].flat_map { |m| m["tests"] }
+      expect(tests.map { |t| t["name"] }).to eq(["test_should_add"])
+      expect(tests[0]["state"]).to eq("passed")
+    end
+  end
+end

--- a/reporters/minitest/spec/reporter_spec.rb
+++ b/reporters/minitest/spec/reporter_spec.rb
@@ -283,4 +283,154 @@ RSpec.describe TddGuardMinitest::Reporter do
       end
     end
   end
+
+  describe ".handle_load_error" do
+    # Helper: run handle_load_error in an isolated tmpdir and return parsed JSON
+    def run_handle_load_error_in(tmpdir, exception)
+      real_tmpdir = File.realpath(tmpdir)
+      Dir.chdir(real_tmpdir) do
+        ClimateControl.modify("TDD_GUARD_PROJECT_ROOT" => real_tmpdir) do
+          described_class.handle_load_error(exception)
+          json_path = File.join(real_tmpdir, default_data_dir, "test.json")
+          JSON.parse(File.read(json_path))
+        end
+      end
+    end
+
+    # Helper: build a LoadError with a synthetic backtrace
+    def build_load_error(message:, backtrace:)
+      err = LoadError.new(message)
+      err.set_backtrace(backtrace)
+      err
+    end
+
+    it "writes a synthetic failed test module" do
+      Dir.mktmpdir do |tmpdir|
+        exc = build_load_error(
+          message: "cannot load such file -- my_class",
+          backtrace: ["./test/my_class_test.rb:3:in `require'"]
+        )
+        data = run_handle_load_error_in(tmpdir, exc)
+
+        tests = data["testModules"].flat_map { |m| m["tests"] }
+        expect(tests.length).to eq(1)
+        expect(tests[0]["state"]).to eq("failed")
+      end
+    end
+
+    it "extracts file path from the first user-land backtrace frame" do
+      Dir.mktmpdir do |tmpdir|
+        exc = build_load_error(
+          message: "cannot load such file -- my_class",
+          backtrace: [
+            "/path/to/gems/bundler-2.0/lib/bundler/runtime.rb:10:in `require'",
+            "./test/my_class_test.rb:3:in `require'",
+            "./test/my_class_test.rb:3:in `<top (required)>'"
+          ]
+        )
+        data = run_handle_load_error_in(tmpdir, exc)
+
+        expect(data["testModules"][0]["moduleId"]).to eq("test/my_class_test.rb")
+      end
+    end
+
+    it "uses exception class and message as the test name" do
+      Dir.mktmpdir do |tmpdir|
+        exc = build_load_error(
+          message: "cannot load such file -- my_class",
+          backtrace: ["./test/my_class_test.rb:3:in `require'"]
+        )
+        data = run_handle_load_error_in(tmpdir, exc)
+
+        tests = data["testModules"].flat_map { |m| m["tests"] }
+        expect(tests[0]["name"]).to eq("LoadError: cannot load such file -- my_class")
+        expect(tests[0]["fullName"]).to eq("test/my_class_test.rb::LoadError: cannot load such file -- my_class")
+      end
+    end
+
+    it "includes the class, message, and backtrace frame in the errors entry" do
+      Dir.mktmpdir do |tmpdir|
+        exc = build_load_error(
+          message: "cannot load such file -- my_class",
+          backtrace: ["./test/my_class_test.rb:3:in `<top (required)>'"]
+        )
+        data = run_handle_load_error_in(tmpdir, exc)
+
+        tests = data["testModules"].flat_map { |m| m["tests"] }
+        error_msg = tests[0]["errors"][0]["message"]
+        expect(error_msg).to include("LoadError")
+        expect(error_msg).to include("cannot load such file -- my_class")
+        expect(error_msg).to include("test/my_class_test.rb")
+      end
+    end
+
+    it "emits reason: failed" do
+      Dir.mktmpdir do |tmpdir|
+        exc = build_load_error(
+          message: "cannot load such file -- my_class",
+          backtrace: ["./test/my_class_test.rb:3:in `require'"]
+        )
+        data = run_handle_load_error_in(tmpdir, exc)
+
+        expect(data["reason"]).to eq("failed")
+      end
+    end
+
+    it "falls back to 'unknown' module when backtrace has only gem frames" do
+      Dir.mktmpdir do |tmpdir|
+        exc = build_load_error(
+          message: "cannot load such file -- my_class",
+          backtrace: [
+            "/path/to/gems/bundler-2.0/lib/bundler/runtime.rb:10:in `require'",
+            "/path/to/gems/minitest-5.27.0/lib/minitest.rb:5:in `require'"
+          ]
+        )
+        data = run_handle_load_error_in(tmpdir, exc)
+
+        expect(data["testModules"][0]["moduleId"]).to eq("unknown")
+      end
+    end
+
+    it "falls back to 'unknown' module when backtrace is nil" do
+      Dir.mktmpdir do |tmpdir|
+        exc = LoadError.new("cannot load such file -- my_class")
+        data = run_handle_load_error_in(tmpdir, exc)
+
+        expect(data["testModules"][0]["moduleId"]).to eq("unknown")
+      end
+    end
+
+    it "accepts any Exception subclass (not just LoadError)" do
+      Dir.mktmpdir do |tmpdir|
+        exc = RuntimeError.new("something else went wrong")
+        exc.set_backtrace(["./test/boom_test.rb:5:in `<top (required)>'"])
+        data = run_handle_load_error_in(tmpdir, exc)
+
+        tests = data["testModules"].flat_map { |m| m["tests"] }
+        expect(tests[0]["name"]).to eq("RuntimeError: something else went wrong")
+        expect(data["testModules"][0]["moduleId"]).to eq("test/boom_test.rb")
+      end
+    end
+
+    it "does not overwrite an existing test.json" do
+      Dir.mktmpdir do |tmpdir|
+        real_tmpdir = File.realpath(tmpdir)
+        Dir.chdir(real_tmpdir) do
+          ClimateControl.modify("TDD_GUARD_PROJECT_ROOT" => real_tmpdir) do
+            json_path = File.join(real_tmpdir, default_data_dir, "test.json")
+            FileUtils.mkdir_p(File.dirname(json_path))
+            File.write(json_path, '{"existing":"results"}')
+
+            exc = build_load_error(
+              message: "cannot load such file -- my_class",
+              backtrace: ["./test/my_class_test.rb:3:in `require'"]
+            )
+            described_class.handle_load_error(exc)
+
+            expect(File.read(json_path)).to eq('{"existing":"results"}')
+          end
+        end
+      end
+    end
+  end
 end

--- a/reporters/test/factories/minitest.ts
+++ b/reporters/test/factories/minitest.ts
@@ -43,7 +43,14 @@ export function createMinitestReporter(): ReporterConfig {
 
       spawnSync(
         bundleBinary,
-        ['exec', 'ruby', '-I', reporterLibPath, testFile],
+        [
+          'exec',
+          'ruby',
+          '-I',
+          reporterLibPath,
+          '-rtdd_guard_minitest/autorun',
+          testFile,
+        ],
         {
           cwd: tempDir,
           env: {

--- a/reporters/test/reporters.integration.test.ts
+++ b/reporters/test/reporters.integration.test.ts
@@ -124,6 +124,7 @@ describe('Reporters', () => {
         { name: 'rust', expected: 'compilation' },
         { name: 'storybook', expected: 'single-import-error.stories' },
         { name: 'rspec', expected: 'single_import_error_spec.rb' },
+        { name: 'minitest', expected: 'single_import_error_test.rb' },
       ]
 
       it.each(reporters)('$name reports module path', ({ name, expected }) => {
@@ -204,6 +205,10 @@ describe('Reporters', () => {
         { name: 'storybook', expected: 'play-test' },
         {
           name: 'rspec',
+          expected: 'LoadError: cannot load such file -- non_existent_module',
+        },
+        {
+          name: 'minitest',
           expected: 'LoadError: cannot load such file -- non_existent_module',
         },
       ]
@@ -346,6 +351,11 @@ describe('Reporters', () => {
           expected:
             'single_import_error_spec.rb::LoadError: cannot load such file -- non_existent_module',
         },
+        {
+          name: 'minitest',
+          expected:
+            'single_import_error_test.rb::LoadError: cannot load such file -- non_existent_module',
+        },
       ]
 
       it.each(reporters)(
@@ -418,6 +428,7 @@ describe('Reporters', () => {
         { name: 'rust', expected: 'failed' },
         { name: 'storybook', expected: 'failed' },
         { name: 'rspec', expected: 'failed' },
+        { name: 'minitest', expected: 'failed' },
       ]
 
       it.each(reporters)(
@@ -588,6 +599,14 @@ describe('Reporters', () => {
             'single_import_error_spec.rb',
           ],
         },
+        {
+          name: 'minitest',
+          expected: [
+            'LoadError',
+            'cannot load such file -- non_existent_module',
+            'single_import_error_test.rb',
+          ],
+        },
       ]
 
       it.each(reporters)(
@@ -668,6 +687,7 @@ describe('Reporters', () => {
         { name: 'rust', expected: 'failed' },
         { name: 'storybook', expected: 'failed' },
         { name: 'rspec', expected: 'failed' },
+        { name: 'minitest', expected: 'failed' },
       ]
 
       it.each(reporters)(


### PR DESCRIPTION
## Summary

- Add `lib/tdd_guard_minitest/autorun.rb` entry point that requires `minitest/autorun` and registers an `at_exit` hook to capture unhandled load errors via `$!`
- Add `Reporter.handle_load_error` that injects a synthetic failed test into `@test_results` and writes `test.json`, mirroring RSpec's `add_load_error_results` (#121); skip writing when `test.json` already exists so the hook never clobbers real results
- Update the integration test factory to invoke Ruby with `-rtdd_guard_minitest/autorun` and add minitest rows to the six "when import errors occur" / "when any import fails" blocks
- Add 9 unit tests and an end-to-end spec that spawns a real Ruby process with a failing `require`
- Update README usage to document `-rtdd_guard_minitest/autorun`, `test/test_helper.rb` integration, and `Rake::TestTask`

When a `require` fails before Minitest runs, Ruby raises `LoadError` before any reporter is initialized -- the reporter previously wrote no `test.json`, so the validator saw no results and blocked creating the missing file. Minitest has no `:message` callback like RSpec, so the fix uses an `at_exit` hook registered after `minitest/autorun` -- it fires before Minitest's own outer `at_exit` (LIFO) and inspects `$!` to capture exceptions raised during test file loading.

Closes #145

Follow-up from #137. cc @nizos
