### PR TITLE
feat(phpunit): relax project root path validation

### DIFF
--- a/reporters/phpunit/README.md
+++ b/reporters/phpunit/README.md
@@ -76,15 +76,11 @@ Use the `projectRoot` parameter in your `phpunit.xml` (see examples above).
 export TDD_GUARD_PROJECT_ROOT=/absolute/path/to/project/root
 ```
 
-**Option 3: Automatic Detection**
-
-If not configured, the reporter will:
-- Use the directory containing `phpunit.xml`
-- Fall back to current working directory
-
 ### Configuration Rules
 
-- Falls back to current directory if configuration is invalid
+- Project root must be configured via the `projectRoot` parameter or `TDD_GUARD_PROJECT_ROOT` environment variable
+- Tests must be run from somewhere within the project root directory
+- Relative paths are supported but resolve against the working directory at runtime — if tests may run from different directories, use an absolute path to ensure results are always written to the correct location
 
 ## More Information
 

--- a/reporters/phpunit/README.md
+++ b/reporters/phpunit/README.md
@@ -84,7 +84,6 @@ If not configured, the reporter will:
 
 ### Configuration Rules
 
-- Path must be absolute
 - Falls back to current directory if configuration is invalid
 
 ## More Information

--- a/reporters/phpunit/src/PathValidator.php
+++ b/reporters/phpunit/src/PathValidator.php
@@ -36,14 +36,6 @@ final class PathValidator
             return null;
         }
 
-        if (!self::isAbsolutePath($path)) {
-            return null;
-        }
-
-        if (strpos($path, '..') !== false) {
-            return null;
-        }
-
         if (!is_dir($path)) {
             return null;
         }
@@ -75,14 +67,5 @@ final class PathValidator
         }
 
         return strpos($path, $potentialAncestor . DIRECTORY_SEPARATOR) === 0;
-    }
-
-    private static function isAbsolutePath(string $path): bool
-    {
-        if (PHP_OS_FAMILY === 'Windows') {
-            return preg_match('/^[a-zA-Z]:[\\\\\\/]/', $path) === 1;
-        }
-
-        return strpos($path, '/') === 0;
     }
 }

--- a/reporters/phpunit/src/PathValidator.php
+++ b/reporters/phpunit/src/PathValidator.php
@@ -27,7 +27,9 @@ final class PathValidator
             return $validated;
         }
 
-        return getcwd();
+        throw new \InvalidArgumentException(
+            'project root must be configured via projectRoot parameter or TDD_GUARD_PROJECT_ROOT environment variable'
+        );
     }
 
     private static function validateProjectRoot(string $path): ?string

--- a/reporters/phpunit/tests/PathValidatorTest.php
+++ b/reporters/phpunit/tests/PathValidatorTest.php
@@ -28,19 +28,6 @@ final class PathValidatorTest extends TestCase
         $this->filesystem->remove($this->tempDir);
     }
 
-    public function testRejectsPathTraversal(): void
-    {
-        // Given: A path with directory traversal
-        $pathWithTraversal = $this->tempDir . '/../dangerous';
-
-        // Then: Should throw exception
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Configured project root is invalid');
-
-        // When: Validating the path
-        PathValidator::resolveProjectRoot($pathWithTraversal);
-    }
-
     public function testAllowsAncestorOfCurrentDirectory(): void
     {
         // Given: Working in a subdirectory
@@ -52,6 +39,44 @@ final class PathValidatorTest extends TestCase
         $result = PathValidator::resolveProjectRoot($this->tempDir);
 
         // Then: Should return the validated path
+        $this->assertEquals(realpath($this->tempDir), $result);
+    }
+
+    public function testAcceptsAbsolutePath(): void
+    {
+        // Given: Working in a directory
+        chdir($this->tempDir);
+
+        // When: Validating the current directory using its absolute path
+        $result = PathValidator::resolveProjectRoot($this->tempDir);
+
+        // Then: Should return the resolved absolute path
+        $this->assertEquals(realpath($this->tempDir), $result);
+    }
+
+    public function testAcceptsRelativePath(): void
+    {
+        // Given: Working in a directory
+        chdir($this->tempDir);
+
+        // When: Validating the current directory using a relative path
+        $result = PathValidator::resolveProjectRoot('.');
+
+        // Then: Should resolve and return the absolute path
+        $this->assertEquals(realpath($this->tempDir), $result);
+    }
+
+    public function testAcceptsPathContainingDotDot(): void
+    {
+        // Given: Working in a subdirectory
+        $subDir = $this->tempDir . '/subdir';
+        $this->filesystem->mkdir($subDir);
+        chdir($subDir);
+
+        // When: Validating a path that uses `..` to reach a valid ancestor
+        $result = PathValidator::resolveProjectRoot($subDir . '/..');
+
+        // Then: Should normalize and return the absolute path
         $this->assertEquals(realpath($this->tempDir), $result);
     }
 

--- a/reporters/phpunit/tests/PathValidatorTest.php
+++ b/reporters/phpunit/tests/PathValidatorTest.php
@@ -80,6 +80,19 @@ final class PathValidatorTest extends TestCase
         $this->assertEquals(realpath($this->tempDir), $result);
     }
 
+    public function testErrorsWhenNoProjectRootConfigured(): void
+    {
+        // Given: No project root configured and no env var set
+        putenv('TDD_GUARD_PROJECT_ROOT');
+
+        // Then: Should throw exception
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('project root must be configured');
+
+        // When: Resolving with empty string
+        PathValidator::resolveProjectRoot('');
+    }
+
     public function testRejectsNonAncestorDirectory(): void
     {
         // Given: Two sibling directories

--- a/reporters/phpunit/tests/TddGuardExtensionFailedTest.php
+++ b/reporters/phpunit/tests/TddGuardExtensionFailedTest.php
@@ -161,7 +161,9 @@ class ErrorTest extends TestCase
          bootstrap="' . dirname(__DIR__) . '/vendor/autoload.php"
          colors="true">
   <extensions>
-    <bootstrap class="TddGuard\\PHPUnit\\TddGuardExtension"/>
+    <bootstrap class="TddGuard\\PHPUnit\\TddGuardExtension">
+      <parameter name="projectRoot" value="' . $this->tempDir . '"/>
+    </bootstrap>
   </extensions>
   <testsuites>
     <testsuite name="test">


### PR DESCRIPTION
## Summary

The PHPUnit reporter no longer requires an absolute path for the project root setting. This unblocks shared repositories and Docker setups where a single absolute path doesn't work across developer machines or host/container boundaries. The reporter now errors when no project root is configured instead of silently defaulting to cwd.


## Details

- The absolute-path requirement and the `..` rejection are removed from `PathValidator`. Both are now handled by PHP's `realpath()`.
- When neither the `projectRoot` parameter nor the `TDD_GUARD_PROJECT_ROOT` environment variable is configured, the reporter errors with a descriptive message. The previous behavior silently defaulted to cwd, which could cause test results to land in the wrong directory if tests ran from a subdirectory.
- The "automatic detection" fallback described in the README (using the phpunit.xml directory) was never implemented — the code defaulted to cwd instead. This section is removed.
- The cwd-within-root sanity check (`isAncestorOrSame`) is preserved. After path resolution, the project root is still required to be an ancestor of (or equal to) the test runner's cwd.

## Notes
- The rationale is recorded in [ADR-009](docs/adr/009-relax-reporter-project-root-validation.md) and [ADR-010](docs/adr/010-standardize-project-root-env-var.md).

Refs #139.