### PR TITLE
feat(minitest): add reason field to test.json output

### DIFF
--- a/reporters/minitest/lib/tdd_guard_minitest/reporter.rb
+++ b/reporters/minitest/lib/tdd_guard_minitest/reporter.rb
@@ -70,7 +70,11 @@ module TddGuardMinitest
         modules_map[module_path]["tests"] << test
       end
 
-      result = { "testModules" => modules_map.values }
+      has_failures = @test_results.any? { |t| t["state"] == "failed" }
+      result = {
+        "testModules" => modules_map.values,
+        "reason" => has_failures ? "failed" : "passed"
+      }
 
       FileUtils.mkdir_p(@storage_dir)
       File.write(File.join(@storage_dir, "test.json"), JSON.pretty_generate(result))

--- a/reporters/minitest/spec/reporter_spec.rb
+++ b/reporters/minitest/spec/reporter_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe TddGuardMinitest::Reporter do
         create_reporter_in(tmpdir) do |reporter, storage_dir|
           data = run_and_read_json(reporter, storage_dir)
           expect(data["testModules"]).to eq([])
+          expect(data["reason"]).to eq("passed")
         end
       end
     end
@@ -138,6 +139,72 @@ RSpec.describe TddGuardMinitest::Reporter do
           service_module = data["testModules"].find { |m| m["moduleId"] == "test/service_test.rb" }
           expect(service_module["tests"].length).to eq(1)
           expect(service_module["tests"][0]["name"]).to eq("test_other")
+        end
+      end
+    end
+  end
+
+  describe "reason field" do
+    it "reports passed when all tests pass" do
+      Dir.mktmpdir do |tmpdir|
+        create_reporter_in(tmpdir) do |reporter, storage_dir|
+          %w[test_one test_two].each do |name|
+            reporter.record(
+              build_result(
+                name: name,
+                klass: "MyClassTest",
+                source_location: ["./test/my_class_test.rb", 5]
+              )
+            )
+          end
+
+          data = run_and_read_json(reporter, storage_dir)
+          expect(data["reason"]).to eq("passed")
+        end
+      end
+    end
+
+    it "reports failed when one test fails" do
+      Dir.mktmpdir do |tmpdir|
+        create_reporter_in(tmpdir) do |reporter, storage_dir|
+          reporter.record(
+            build_result(
+              name: "test_passes",
+              klass: "MyClassTest",
+              source_location: ["./test/my_class_test.rb", 5]
+            )
+          )
+          reporter.record(
+            build_result(
+              name: "test_fails",
+              klass: "MyClassTest",
+              source_location: ["./test/my_class_test.rb", 10],
+              failures: [build_assertion_failure(message: "expected true")]
+            )
+          )
+
+          data = run_and_read_json(reporter, storage_dir)
+          expect(data["reason"]).to eq("failed")
+        end
+      end
+    end
+
+    it "reports failed when all tests fail" do
+      Dir.mktmpdir do |tmpdir|
+        create_reporter_in(tmpdir) do |reporter, storage_dir|
+          %w[test_one test_two].each do |name|
+            reporter.record(
+              build_result(
+                name: name,
+                klass: "MyClassTest",
+                source_location: ["./test/my_class_test.rb", 5],
+                failures: [build_assertion_failure(message: "error")]
+              )
+            )
+          end
+
+          data = run_and_read_json(reporter, storage_dir)
+          expect(data["reason"]).to eq("failed")
         end
       end
     end

--- a/reporters/test/reporters.integration.test.ts
+++ b/reporters/test/reporters.integration.test.ts
@@ -637,7 +637,7 @@ describe('Reporters', () => {
         { name: 'rust', expected: 'passed' },
         { name: 'storybook', expected: 'passed' },
         { name: 'rspec', expected: 'passed' },
-        { name: 'minitest', expected: undefined },
+        { name: 'minitest', expected: 'passed' },
       ]
 
       it.each(reporters)(
@@ -662,7 +662,7 @@ describe('Reporters', () => {
         { name: 'rust', expected: 'failed' },
         { name: 'storybook', expected: 'failed' },
         { name: 'rspec', expected: 'failed' },
-        { name: 'minitest', expected: undefined },
+        { name: 'minitest', expected: 'failed' },
       ]
 
       it.each(reporters)(


### PR DESCRIPTION
## Summary

- Derive overall test run reason from individual test states in the Minitest reporter `report` method
- Report `"failed"` when any test has failed state, `"passed"` otherwise
- Add 3 unit tests covering all pass, one fail, and all fail scenarios, plus extend the existing empty-testModules test to assert `"passed"`
- Update integration test expectations for minitest from `undefined` to `passed`/`failed`

This follows the same pattern used by the RSpec reporter (#123) and the PHPUnit and Go reporters. The load-error synthetic-failure path added in #145 already emits `"reason": "failed"` through its own write path, so it is unaffected by this change.

Closes #146

Follow-up from #145. cc @nizos
