### PR TITLE
feat(go): go relax project root path validation

### DIFF
--- a/reporters/go/README.md
+++ b/reporters/go/README.md
@@ -38,7 +38,7 @@ Alternatively, set the `TDD_GUARD_PROJECT_ROOT` environment variable. The CLI fl
 ### Configuration Rules
 
 - Project root must be configured via `-project-root` flag or `TDD_GUARD_PROJECT_ROOT` environment variable
-- Current directory must be within the configured project root
+- Tests must be run from somewhere within the project root directory
 - Relative paths are supported but resolve against the working directory at runtime — if tests may run from different directories, use an absolute path to ensure results are always written to the correct location
 
 ### Makefile Integration

--- a/reporters/go/README.md
+++ b/reporters/go/README.md
@@ -28,12 +28,11 @@ go test -json ./... 2>&1 | tdd-guard-go
 For projects where tests run in subdirectories, specify the project root:
 
 ```bash
-go test -json ./... 2>&1 | tdd-guard-go -project-root /absolute/path/to/project/root
+go test -json ./... 2>&1 | tdd-guard-go -project-root path/to/project/root
 ```
 
 ### Configuration Rules
 
-- Path must be absolute when using `-project-root` flag
 - Current directory must be within the configured project root
 - Falls back to current directory if not specified
 
@@ -43,7 +42,7 @@ Add to your `Makefile`:
 
 ```makefile
 test:
-	go test -json ./... 2>&1 | tdd-guard-go -project-root /absolute/path/to/project/root
+	go test -json ./... 2>&1 | tdd-guard-go -project-root path/to/project/root
 ```
 
 ## How It Works

--- a/reporters/go/README.md
+++ b/reporters/go/README.md
@@ -31,10 +31,15 @@ For projects where tests run in subdirectories, specify the project root:
 go test -json ./... 2>&1 | tdd-guard-go -project-root path/to/project/root
 ```
 
+### Environment Variable
+
+Alternatively, set the `TDD_GUARD_PROJECT_ROOT` environment variable. The CLI flag takes precedence if both are provided.
+
 ### Configuration Rules
 
+- Project root must be configured via `-project-root` flag or `TDD_GUARD_PROJECT_ROOT` environment variable
 - Current directory must be within the configured project root
-- Falls back to current directory if not specified
+- Relative paths are supported but resolve against the working directory at runtime — if tests may run from different directories, use an absolute path to ensure results are always written to the correct location
 
 ### Makefile Integration
 

--- a/reporters/go/cmd/tdd-guard-go/main.go
+++ b/reporters/go/cmd/tdd-guard-go/main.go
@@ -21,7 +21,7 @@ import (
 
 func main() {
 	var projectRoot string
-	flag.StringVar(&projectRoot, "project-root", "", "Project root directory (absolute path)")
+	flag.StringVar(&projectRoot, "project-root", "", "Project root directory")
 	flag.Parse()
 
 	if err := process(os.Stdin, projectRoot, os.Stdout); err != nil {
@@ -30,7 +30,8 @@ func main() {
 }
 
 func process(input io.Reader, projectRoot string, output io.Writer) error {
-	if err := validateProjectRoot(projectRoot); err != nil {
+	resolvedRoot, err := resolveProjectRoot(projectRoot)
+	if err != nil {
 		return err
 	}
 
@@ -60,7 +61,7 @@ func process(input io.Reader, projectRoot string, output io.Writer) error {
 	t := transformer.NewTransformer()
 	result := t.Transform(results, p, mixedReader.CompilationError)
 
-	s := storage.NewStorage(projectRoot)
+	s := storage.NewStorage(resolvedRoot)
 	return s.Save(result)
 }
 
@@ -86,21 +87,22 @@ func formatAndOutput(input io.Reader, output io.Writer) {
 	}
 }
 
-func validateProjectRoot(projectRoot string) error {
-	if projectRoot == "" {
-		return nil
+func resolveProjectRoot(projectRoot string) (string, error) {
+	resolved, err := filepath.Abs(projectRoot)
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve project root: %w", err)
 	}
 
-	if !filepath.IsAbs(projectRoot) {
-		return errors.New("project root must be an absolute path")
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine current directory: %w", err)
 	}
 
-	cwd, _ := os.Getwd()
-	if !strings.HasPrefix(cwd, projectRoot) {
-		return errors.New("current directory must be within project root")
+	if !strings.HasPrefix(cwd, resolved) {
+		return "", errors.New("current directory must be within project root")
 	}
 
-	return nil
+	return resolved, nil
 }
 
 func parseTestResults(mixedReader *parser.MixedReader) (parser.Results, *parser.Parser, error) {

--- a/reporters/go/cmd/tdd-guard-go/main.go
+++ b/reporters/go/cmd/tdd-guard-go/main.go
@@ -88,6 +88,13 @@ func formatAndOutput(input io.Reader, output io.Writer) {
 }
 
 func resolveProjectRoot(projectRoot string) (string, error) {
+	if projectRoot == "" {
+		projectRoot = os.Getenv("TDD_GUARD_PROJECT_ROOT")
+	}
+	if projectRoot == "" {
+		return "", errors.New("project root must be configured via -project-root flag or TDD_GUARD_PROJECT_ROOT environment variable")
+	}
+
 	resolved, err := filepath.Abs(projectRoot)
 	if err != nil {
 		return "", fmt.Errorf("cannot resolve project root: %w", err)

--- a/reporters/go/cmd/tdd-guard-go/main_test.go
+++ b/reporters/go/cmd/tdd-guard-go/main_test.go
@@ -21,8 +21,18 @@ func TestProcess(t *testing.T) {
 	})
 
 	t.Run("without project root", func(t *testing.T) {
-		t.Run("creates output file", func(t *testing.T) {
-			runProcess(t, "")
+		t.Run("errors when no project root is configured", func(t *testing.T) {
+			err := runProcess(t, "")
+			assertErrorContains(t, err, "project root must be configured")
+		})
+
+		t.Run("uses TDD_GUARD_PROJECT_ROOT env var as fallback", func(t *testing.T) {
+			t.Setenv("TDD_GUARD_PROJECT_ROOT", tempDir)
+
+			err := runProcess(t, "")
+			if err != nil {
+				t.Fatalf("Expected no error with env var set, got: %v", err)
+			}
 			assertFileExists(t, tempDir)
 		})
 	})

--- a/reporters/go/cmd/tdd-guard-go/main_test.go
+++ b/reporters/go/cmd/tdd-guard-go/main_test.go
@@ -54,11 +54,7 @@ func TestProcess(t *testing.T) {
 		})
 
 		t.Run("accepts relative path", func(t *testing.T) {
-			subDir := filepath.Join(tempDir, "reltest")
-			os.MkdirAll(subDir, 0755)
-			oldCwd, _ := os.Getwd()
-			os.Chdir(subDir)
-			defer os.Chdir(oldCwd)
+			subDir := chdirToSubDir(t, tempDir, "reltest")
 
 			err := runProcess(t, ".")
 			if err != nil {
@@ -68,11 +64,7 @@ func TestProcess(t *testing.T) {
 		})
 
 		t.Run("accepts path containing ..", func(t *testing.T) {
-			subDir := filepath.Join(tempDir, "dotdot")
-			os.MkdirAll(subDir, 0755)
-			oldCwd, _ := os.Getwd()
-			os.Chdir(subDir)
-			defer os.Chdir(oldCwd)
+			subDir := chdirToSubDir(t, tempDir, "dotdot")
 
 			err := runProcess(t, filepath.Join(subDir, ".."))
 			if err != nil {
@@ -91,11 +83,7 @@ func TestProcess(t *testing.T) {
 		})
 
 		t.Run("accepts ancestor of current directory", func(t *testing.T) {
-			subDir := filepath.Join(tempDir, "ancestor")
-			os.MkdirAll(subDir, 0755)
-			oldCwd, _ := os.Getwd()
-			os.Chdir(subDir)
-			defer os.Chdir(oldCwd)
+			chdirToSubDir(t, tempDir, "ancestor")
 
 			err := runProcess(t, tempDir)
 			if err != nil {
@@ -113,20 +101,11 @@ func TestProcess(t *testing.T) {
 		})
 
 		t.Run("returns error when current directory is unavailable", func(t *testing.T) {
-			doomed := filepath.Join(tempDir, "doomed")
-			os.MkdirAll(doomed, 0755)
-			oldCwd, _ := os.Getwd()
-			os.Chdir(doomed)
-			defer os.Chdir(oldCwd)
-			os.RemoveAll(doomed)
+			subDir := chdirToSubDir(t, tempDir, "doomed")
+			os.RemoveAll(subDir)
 
 			err := runProcess(t, tempDir)
-			if err == nil {
-				t.Fatal("Expected error when current directory is unavailable")
-			}
-			if !strings.Contains(err.Error(), "cannot determine current directory") {
-				t.Fatalf("Expected error about current directory, got: %v", err)
-			}
+			assertErrorContains(t, err, "cannot determine current directory")
 		})
 	})
 
@@ -303,9 +282,19 @@ func assertFileExists(t *testing.T, projectRoot string) {
 
 func assertErrorContains(t *testing.T, err error, expected string) {
 	t.Helper()
-	if err == nil || err.Error() != expected {
-		t.Fatalf("Expected error '%s', got: %v", expected, err)
+	if err == nil || !strings.Contains(err.Error(), expected) {
+		t.Fatalf("Expected error containing '%s', got: %v", expected, err)
 	}
+}
+
+func chdirToSubDir(t *testing.T, parent string, name string) string {
+	t.Helper()
+	subDir := filepath.Join(parent, name)
+	os.MkdirAll(subDir, 0755)
+	oldCwd, _ := os.Getwd()
+	os.Chdir(subDir)
+	t.Cleanup(func() { os.Chdir(oldCwd) })
+	return subDir
 }
 
 func getTestFilePath(projectRoot string) string {

--- a/reporters/go/cmd/tdd-guard-go/main_test.go
+++ b/reporters/go/cmd/tdd-guard-go/main_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/nizos/tdd-guard/reporters/go/internal/storage"
@@ -41,48 +42,91 @@ func TestProcess(t *testing.T) {
 				t.Fatalf("Expected output to contain transformed test state, got: %s", data)
 			}
 		})
+	})
 
-		t.Run("accepts project root equal to current directory", func(t *testing.T) {
-			cwd, _ := os.Getwd()
-
-			err := runProcess(t, cwd)
+	t.Run("project root resolution", func(t *testing.T) {
+		t.Run("accepts absolute path", func(t *testing.T) {
+			err := runProcess(t, tempDir)
 			if err != nil {
-				t.Fatalf("Expected no error when project root equals cwd, got: %v", err)
+				t.Fatalf("Expected no error for absolute path, got: %v", err)
 			}
-
-			assertFileExists(t, cwd)
+			assertFileExists(t, tempDir)
 		})
 
-		t.Run("accepts project root as ancestor of current directory", func(t *testing.T) {
-			// Create a subdirectory and change to it
-			subDir := filepath.Join(tempDir, "subdir")
+		t.Run("accepts relative path", func(t *testing.T) {
+			subDir := filepath.Join(tempDir, "reltest")
 			os.MkdirAll(subDir, 0755)
 			oldCwd, _ := os.Getwd()
 			os.Chdir(subDir)
 			defer os.Chdir(oldCwd)
 
-			// Use tempDir (parent) as project root
+			err := runProcess(t, ".")
+			if err != nil {
+				t.Fatalf("Expected no error for relative path, got: %v", err)
+			}
+			assertFileExists(t, subDir)
+		})
+
+		t.Run("accepts path containing ..", func(t *testing.T) {
+			subDir := filepath.Join(tempDir, "dotdot")
+			os.MkdirAll(subDir, 0755)
+			oldCwd, _ := os.Getwd()
+			os.Chdir(subDir)
+			defer os.Chdir(oldCwd)
+
+			err := runProcess(t, filepath.Join(subDir, ".."))
+			if err != nil {
+				t.Fatalf("Expected no error for path with .., got: %v", err)
+			}
+			assertFileExists(t, tempDir)
+		})
+
+		t.Run("accepts path equal to current directory", func(t *testing.T) {
+			cwd, _ := os.Getwd()
+			err := runProcess(t, cwd)
+			if err != nil {
+				t.Fatalf("Expected no error when project root equals cwd, got: %v", err)
+			}
+			assertFileExists(t, cwd)
+		})
+
+		t.Run("accepts ancestor of current directory", func(t *testing.T) {
+			subDir := filepath.Join(tempDir, "ancestor")
+			os.MkdirAll(subDir, 0755)
+			oldCwd, _ := os.Getwd()
+			os.Chdir(subDir)
+			defer os.Chdir(oldCwd)
+
 			err := runProcess(t, tempDir)
 			if err != nil {
 				t.Fatalf("Expected no error when project root is ancestor, got: %v", err)
 			}
-
 			assertFileExists(t, tempDir)
 		})
-	})
 
-	t.Run("project root validation", func(t *testing.T) {
-		t.Run("rejects relative project root", func(t *testing.T) {
-			err := runProcess(t, "../relative/path")
-			assertErrorContains(t, err, "project root must be an absolute path")
-		})
-
-		t.Run("rejects project root outside current directory", func(t *testing.T) {
+		t.Run("rejects path outside current directory", func(t *testing.T) {
 			outsideRoot := filepath.Join(filepath.Dir(tempDir), "outside")
 			os.MkdirAll(outsideRoot, 0755)
 
 			err := runProcess(t, outsideRoot)
 			assertErrorContains(t, err, "current directory must be within project root")
+		})
+
+		t.Run("returns error when current directory is unavailable", func(t *testing.T) {
+			doomed := filepath.Join(tempDir, "doomed")
+			os.MkdirAll(doomed, 0755)
+			oldCwd, _ := os.Getwd()
+			os.Chdir(doomed)
+			defer os.Chdir(oldCwd)
+			os.RemoveAll(doomed)
+
+			err := runProcess(t, tempDir)
+			if err == nil {
+				t.Fatal("Expected error when current directory is unavailable")
+			}
+			if !strings.Contains(err.Error(), "cannot determine current directory") {
+				t.Fatalf("Expected error about current directory, got: %v", err)
+			}
 		})
 	})
 


### PR DESCRIPTION
## Summary

The Go reporter no longer requires an absolute path for the project root setting. Relative paths and paths containing `..` are now resolved against the test runner's current working directory. The reporter now reads `TDD_GUARD_PROJECT_ROOT` as a fallback and errors when no project root is configured.

## Details

- The project root is now resolved rather than just validated in order to support relative paths and paths that traverse upwards.
- `TDD_GUARD_PROJECT_ROOT` environment variable is read when no `-project-root` flag is provided. When neither is configured, the reporter errors instead of silently defaulting to cwd.
- The cwd-within-root sanity check is preserved. After resolution, the project root is still required to be an ancestor of the test runner's cwd.
- Made minor improvements to test helpers for more focused tests

## Notes
- The rationale for the relaxation is recorded in [ADR-009](docs/adr/009-relax-reporter-project-root-validation.md) and [ADR-010](docs/adr/010-standardize-project-root-env-var.md).