### PR TITLE
feat(rust): relax project root path validation

### DIFF
--- a/reporters/rust/README.md
+++ b/reporters/rust/README.md
@@ -71,13 +71,19 @@ test-tdd:
 
 ### Project Root
 
-The `--project-root` flag sets the project root directory. Test results are written to `.claude/tdd-guard/data/test.json` relative to this path. If omitted, defaults to the current working directory.
+The `--project-root` flag sets the project root directory. Test results are written to `.claude/tdd-guard/data/test.json` relative to this path. Alternatively, set the `TDD_GUARD_PROJECT_ROOT` environment variable. The CLI flag takes precedence if both are provided.
+
+### Configuration Rules
+
+- Project root must be configured via `--project-root` flag or `TDD_GUARD_PROJECT_ROOT` environment variable
+- Tests must be run from somewhere within the project root directory
+- Relative paths are supported but resolve against the working directory at runtime — if tests may run from different directories, use an absolute path to ensure results are always written to the correct location
 
 ### Flags
 
 - `--passthrough`: Force passthrough mode even if stdin is a terminal
 - `--runner [auto|nextest|cargo]`: Choose test runner for direct execution (default: auto)
-- `--project-root`: Path to project root directory (defaults to current working directory)
+- `--project-root`: Path to project root directory
 
 ## How It Works
 

--- a/reporters/rust/README.md
+++ b/reporters/rust/README.md
@@ -31,13 +31,13 @@ The reporter works as a filter that processes test output while passing it throu
 ### With cargo-nextest (Recommended)
 
 ```bash
-cargo nextest run 2>&1 | tdd-guard-rust --project-root /absolute/path/to/project
+cargo nextest run 2>&1 | tdd-guard-rust --project-root path/to/project
 ```
 
 ### With cargo test
 
 ```bash
-cargo test -- -Z unstable-options --format json 2>&1 | tdd-guard-rust --project-root /absolute/path/to/project
+cargo test -- -Z unstable-options --format json 2>&1 | tdd-guard-rust --project-root path/to/project
 ```
 
 ### Direct Execution
@@ -46,11 +46,11 @@ The reporter can also execute tests directly:
 
 ```bash
 # Auto-detect runner (prefers nextest)
-tdd-guard-rust --project-root /absolute/path/to/project
+tdd-guard-rust --project-root path/to/project
 
 # Force specific runner
-tdd-guard-rust --project-root /absolute/path/to/project --runner nextest
-tdd-guard-rust --project-root /absolute/path/to/project --runner cargo
+tdd-guard-rust --project-root path/to/project --runner nextest
+tdd-guard-rust --project-root path/to/project --runner cargo
 ```
 
 ## Makefile Integration
@@ -71,13 +71,13 @@ test-tdd:
 
 ### Project Root
 
-The `--project-root` flag must be an absolute path to your project directory. This is where the `.claude/tdd-guard/data/test.json` file will be written.
+The `--project-root` flag sets the project root directory. Test results are written to `.claude/tdd-guard/data/test.json` relative to this path. If omitted, defaults to the current working directory.
 
 ### Flags
 
 - `--passthrough`: Force passthrough mode even if stdin is a terminal
 - `--runner [auto|nextest|cargo]`: Choose test runner for direct execution (default: auto)
-- `--project-root`: Absolute path to project directory (required)
+- `--project-root`: Path to project root directory (defaults to current working directory)
 
 ## How It Works
 

--- a/reporters/rust/src/error_parser.rs
+++ b/reporters/rust/src/error_parser.rs
@@ -33,12 +33,9 @@ fn strip_ansi_codes(s: &str) -> String {
 /// Parse a buffer of lines to extract compilation errors
 pub fn parse_error_buffer(lines: &[String]) -> Vec<CompilationError> {
     // Preprocess: strip ANSI codes from all lines once
-    let cleaned: Vec<String> = lines
-        .iter()
-        .map(|line| strip_ansi_codes(line))
-        .collect();
+    let cleaned: Vec<String> = lines.iter().map(|line| strip_ansi_codes(line)).collect();
     let lines = &cleaned[..];
-    
+
     let mut errors = Vec::new();
     let mut current_error: Option<CompilationError> = None;
 
@@ -289,16 +286,15 @@ mod tests {
         );
     }
 
-
     #[test]
     fn test_parse_error_with_ansi_colors() {
         let lines = vec![
             "\u{1b}[0m\u{1b}[1m\u{1b}[38;5;9merror[E0432]\u{1b}[0m\u{1b}[0m\u{1b}[1m: unresolved import `non_existent_module`\u{1b}[0m".to_string(),
             "\u{1b}[0m \u{1b}[0m\u{1b}[0m\u{1b}[1m\u{1b}[38;5;12m--> \u{1b}[0m\u{1b}[0msrc/lib.rs:1:5\u{1b}[0m".to_string(),
         ];
-        
+
         let errors = parse_error_buffer(&lines);
-        
+
         assert_eq!(errors.len(), 1);
         assert_eq!(errors[0].code, Some("E0432".to_string()));
         assert_eq!(errors[0].message, "unresolved import `non_existent_module`");

--- a/reporters/rust/src/main.rs
+++ b/reporters/rust/src/main.rs
@@ -212,17 +212,22 @@ fn process_output(
 }
 
 fn resolve_project_root(project_root: Option<&str>, base_dir: &Path) -> io::Result<PathBuf> {
-    let path = match project_root {
-        Some(root) => {
-            let p = PathBuf::from(root);
-            if p.is_absolute() {
-                p
-            } else {
-                base_dir.join(p)
-            }
-        }
-        None => base_dir.to_path_buf(),
-    };
+    let env_root = std::env::var("TDD_GUARD_PROJECT_ROOT")
+        .ok()
+        .filter(|s| !s.is_empty());
+    let root_str = project_root
+        .map(|s| s.to_string())
+        .or(env_root)
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "project root must be configured via --project-root flag or TDD_GUARD_PROJECT_ROOT environment variable",
+            )
+        })?;
+    let root = root_str.as_str();
+
+    let p = PathBuf::from(root);
+    let path = if p.is_absolute() { p } else { base_dir.join(p) };
     path.canonicalize()
 }
 
@@ -305,14 +310,36 @@ mod tests {
     }
 
     #[test]
-    fn test_run_defaults_to_cwd_without_project_root() {
+    fn test_run_uses_env_var_as_fallback() {
+        let ctx = TestContext::setup();
+
+        std::env::set_var("TDD_GUARD_PROJECT_ROOT", ctx.project_root.to_str().unwrap());
+        let args = TestContext::make_args(None);
+        let result = run(&args, &ctx.project_root);
+        std::env::remove_var("TDD_GUARD_PROJECT_ROOT");
+
+        assert!(
+            result.is_ok(),
+            "Expected success with env var, got: {:?}",
+            result.err()
+        );
+        assert!(TestContext::test_json_path(&ctx.project_root).exists());
+    }
+
+    #[test]
+    fn test_run_errors_when_no_project_root_configured() {
         let ctx = TestContext::setup();
 
         let args = TestContext::make_args(None);
         let result = run(&args, &ctx.project_root);
 
-        assert!(result.is_ok(), "Expected success, got: {:?}", result.err());
-        assert!(TestContext::test_json_path(&ctx.project_root).exists());
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("project root must be configured"),
+            "Expected error about missing config, got: {}",
+            err
+        );
     }
 
     #[test]
@@ -344,12 +371,11 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_defaults_to_base_dir_when_none() {
+    fn test_resolve_errors_when_none() {
         let ctx = TestContext::setup();
 
         let result = resolve_project_root(None, &ctx.project_root);
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), ctx.project_root.canonicalize().unwrap());
+        assert!(result.is_err());
     }
 
     #[test]

--- a/reporters/rust/src/main.rs
+++ b/reporters/rust/src/main.rs
@@ -23,9 +23,9 @@ use transformer::{transform_events, TddGuardOutput};
     Supports both cargo test and cargo nextest with optional JSON output for detailed reporting."
 )]
 struct Args {
-    /// Absolute path to project root directory
+    /// Path to project root directory
     #[arg(long, value_name = "PATH")]
-    project_root: String,
+    project_root: Option<String>,
 
     /// Pass through mode - read from stdin instead of running tests
     #[arg(long, default_value_t = false)]
@@ -47,30 +47,22 @@ struct Args {
 fn main() -> io::Result<()> {
     let args = Args::parse();
 
-    let project_root = PathBuf::from(&args.project_root);
-    if !project_root.is_absolute() {
-        eprintln!("Error: project-root must be an absolute path");
-        std::process::exit(1);
-    }
+    let exit_code = run(&args, &std::env::current_dir()?)?;
 
-    if !project_root.exists() {
-        eprintln!(
-            "Error: project-root does not exist: {}",
-            project_root.display()
-        );
-        std::process::exit(1);
-    }
+    std::process::exit(exit_code);
+}
+
+fn run(args: &Args, base_dir: &Path) -> io::Result<i32> {
+    let project_root = resolve_project_root(args.project_root.as_deref(), base_dir)?;
 
     let auto_enabled = !args.no_auto_passthrough && env_auto_enabled();
     let use_pass = should_passthrough(args.passthrough, auto_enabled);
 
-    let exit_code = if use_pass {
-        process_passthrough(&project_root)?
+    if use_pass {
+        process_passthrough(&project_root)
     } else {
-        run_and_process(&args, &project_root)?
-    };
-
-    std::process::exit(exit_code);
+        run_and_process(args, &project_root)
+    }
 }
 
 /// Unified function to run tests and process output
@@ -300,6 +292,47 @@ fn should_passthrough(explicit: bool, auto_enabled: bool) -> bool {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    fn make_args(project_root: Option<&str>) -> Args {
+        Args {
+            project_root: project_root.map(|s| s.to_string()),
+            passthrough: true,
+            no_auto_passthrough: true,
+            runner: "auto".to_string(),
+            test_args: vec![],
+        }
+    }
+
+    fn test_json_path(root: &Path) -> PathBuf {
+        root.join(".claude")
+            .join("tdd-guard")
+            .join("data")
+            .join("test.json")
+    }
+
+    #[test]
+    fn test_run_accepts_relative_project_root() {
+        let temp_dir = TempDir::new().unwrap();
+        let sub_dir = temp_dir.path().join("reltest");
+        fs::create_dir_all(&sub_dir).unwrap();
+
+        let args = make_args(Some("."));
+        let result = run(&args, &sub_dir);
+
+        assert!(result.is_ok(), "Expected success, got: {:?}", result.err());
+        assert!(test_json_path(&sub_dir).exists());
+    }
+
+    #[test]
+    fn test_run_defaults_to_cwd_without_project_root() {
+        let temp_dir = TempDir::new().unwrap();
+
+        let args = make_args(None);
+        let result = run(&args, temp_dir.path());
+
+        assert!(result.is_ok(), "Expected success, got: {:?}", result.err());
+        assert!(test_json_path(temp_dir.path()).exists());
+    }
 
     #[test]
     fn test_resolve_accepts_absolute_path() {

--- a/reporters/rust/src/main.rs
+++ b/reporters/rust/src/main.rs
@@ -219,6 +219,11 @@ fn process_output(
     Ok(())
 }
 
+fn resolve_project_root(project_root: Option<&str>) -> io::Result<PathBuf> {
+    let path = PathBuf::from(project_root.unwrap_or("."));
+    path.canonicalize()
+}
+
 /// Save test results to TDD Guard format
 fn save_results(project_root: &Path, output: &TddGuardOutput) -> io::Result<()> {
     let output_dir = project_root.join(".claude").join("tdd-guard").join("data");
@@ -285,6 +290,58 @@ fn should_passthrough(explicit: bool, auto_enabled: bool) -> bool {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    fn test_resolve_accepts_absolute_path() {
+        let temp_dir = TempDir::new().unwrap();
+        let result = resolve_project_root(Some(temp_dir.path().to_str().unwrap()));
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), temp_dir.path().canonicalize().unwrap());
+    }
+
+    #[test]
+    fn test_resolve_accepts_relative_path() {
+        let temp_dir = TempDir::new().unwrap();
+        let sub_dir = temp_dir.path().join("reltest");
+        fs::create_dir_all(&sub_dir).unwrap();
+        let original_dir = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&sub_dir).unwrap();
+
+        let result = resolve_project_root(Some("."));
+        std::env::set_current_dir(&original_dir).unwrap();
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), sub_dir.canonicalize().unwrap());
+    }
+
+    #[test]
+    fn test_resolve_accepts_path_containing_dotdot() {
+        let temp_dir = TempDir::new().unwrap();
+        let sub_dir = temp_dir.path().join("dotdot");
+        fs::create_dir_all(&sub_dir).unwrap();
+        let original_dir = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&sub_dir).unwrap();
+
+        let input = sub_dir.join("..").to_str().unwrap().to_string();
+        let result = resolve_project_root(Some(&input));
+        std::env::set_current_dir(&original_dir).unwrap();
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), temp_dir.path().canonicalize().unwrap());
+    }
+
+    #[test]
+    fn test_resolve_defaults_to_cwd_when_none() {
+        let temp_dir = TempDir::new().unwrap();
+        let original_dir = std::env::current_dir().unwrap();
+        std::env::set_current_dir(temp_dir.path()).unwrap();
+
+        let result = resolve_project_root(None);
+        std::env::set_current_dir(&original_dir).unwrap();
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), temp_dir.path().canonicalize().unwrap());
+    }
 
     #[test]
     fn test_save_results() {

--- a/reporters/rust/src/main.rs
+++ b/reporters/rust/src/main.rs
@@ -219,8 +219,18 @@ fn process_output(
     Ok(())
 }
 
-fn resolve_project_root(project_root: Option<&str>) -> io::Result<PathBuf> {
-    let path = PathBuf::from(project_root.unwrap_or("."));
+fn resolve_project_root(project_root: Option<&str>, base_dir: &Path) -> io::Result<PathBuf> {
+    let path = match project_root {
+        Some(root) => {
+            let p = PathBuf::from(root);
+            if p.is_absolute() {
+                p
+            } else {
+                base_dir.join(p)
+            }
+        }
+        None => base_dir.to_path_buf(),
+    };
     path.canonicalize()
 }
 
@@ -294,7 +304,7 @@ mod tests {
     #[test]
     fn test_resolve_accepts_absolute_path() {
         let temp_dir = TempDir::new().unwrap();
-        let result = resolve_project_root(Some(temp_dir.path().to_str().unwrap()));
+        let result = resolve_project_root(Some(temp_dir.path().to_str().unwrap()), temp_dir.path());
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), temp_dir.path().canonicalize().unwrap());
     }
@@ -304,12 +314,8 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let sub_dir = temp_dir.path().join("reltest");
         fs::create_dir_all(&sub_dir).unwrap();
-        let original_dir = std::env::current_dir().unwrap();
-        std::env::set_current_dir(&sub_dir).unwrap();
 
-        let result = resolve_project_root(Some("."));
-        std::env::set_current_dir(&original_dir).unwrap();
-
+        let result = resolve_project_root(Some("."), &sub_dir);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), sub_dir.canonicalize().unwrap());
     }
@@ -319,26 +325,18 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let sub_dir = temp_dir.path().join("dotdot");
         fs::create_dir_all(&sub_dir).unwrap();
-        let original_dir = std::env::current_dir().unwrap();
-        std::env::set_current_dir(&sub_dir).unwrap();
 
         let input = sub_dir.join("..").to_str().unwrap().to_string();
-        let result = resolve_project_root(Some(&input));
-        std::env::set_current_dir(&original_dir).unwrap();
-
+        let result = resolve_project_root(Some(&input), &sub_dir);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), temp_dir.path().canonicalize().unwrap());
     }
 
     #[test]
-    fn test_resolve_defaults_to_cwd_when_none() {
+    fn test_resolve_defaults_to_base_dir_when_none() {
         let temp_dir = TempDir::new().unwrap();
-        let original_dir = std::env::current_dir().unwrap();
-        std::env::set_current_dir(temp_dir.path()).unwrap();
 
-        let result = resolve_project_root(None);
-        std::env::set_current_dir(&original_dir).unwrap();
-
+        let result = resolve_project_root(None, temp_dir.path());
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), temp_dir.path().canonicalize().unwrap());
     }

--- a/reporters/rust/src/main.rs
+++ b/reporters/rust/src/main.rs
@@ -293,111 +293,81 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
-    fn make_args(project_root: Option<&str>) -> Args {
-        Args {
-            project_root: project_root.map(|s| s.to_string()),
-            passthrough: true,
-            no_auto_passthrough: true,
-            runner: "auto".to_string(),
-            test_args: vec![],
-        }
-    }
-
-    fn test_json_path(root: &Path) -> PathBuf {
-        root.join(".claude")
-            .join("tdd-guard")
-            .join("data")
-            .join("test.json")
-    }
-
     #[test]
     fn test_run_accepts_relative_project_root() {
-        let temp_dir = TempDir::new().unwrap();
-        let sub_dir = temp_dir.path().join("reltest");
-        fs::create_dir_all(&sub_dir).unwrap();
+        let ctx = TestContext::setup().with_sub_dir();
 
-        let args = make_args(Some("."));
-        let result = run(&args, &sub_dir);
+        let args = TestContext::make_args(Some("."));
+        let result = run(&args, &ctx.base_dir);
 
         assert!(result.is_ok(), "Expected success, got: {:?}", result.err());
-        assert!(test_json_path(&sub_dir).exists());
+        assert!(TestContext::test_json_path(&ctx.base_dir).exists());
     }
 
     #[test]
     fn test_run_defaults_to_cwd_without_project_root() {
-        let temp_dir = TempDir::new().unwrap();
+        let ctx = TestContext::setup();
 
-        let args = make_args(None);
-        let result = run(&args, temp_dir.path());
+        let args = TestContext::make_args(None);
+        let result = run(&args, &ctx.project_root);
 
         assert!(result.is_ok(), "Expected success, got: {:?}", result.err());
-        assert!(test_json_path(temp_dir.path()).exists());
+        assert!(TestContext::test_json_path(&ctx.project_root).exists());
     }
 
     #[test]
     fn test_resolve_accepts_absolute_path() {
-        let temp_dir = TempDir::new().unwrap();
-        let result = resolve_project_root(Some(temp_dir.path().to_str().unwrap()), temp_dir.path());
+        let ctx = TestContext::setup();
+        let result =
+            resolve_project_root(Some(ctx.project_root.to_str().unwrap()), &ctx.project_root);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), temp_dir.path().canonicalize().unwrap());
+        assert_eq!(result.unwrap(), ctx.project_root.canonicalize().unwrap());
     }
 
     #[test]
     fn test_resolve_accepts_relative_path() {
-        let temp_dir = TempDir::new().unwrap();
-        let sub_dir = temp_dir.path().join("reltest");
-        fs::create_dir_all(&sub_dir).unwrap();
+        let ctx = TestContext::setup().with_sub_dir();
 
-        let result = resolve_project_root(Some("."), &sub_dir);
+        let result = resolve_project_root(Some("."), &ctx.base_dir);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), sub_dir.canonicalize().unwrap());
+        assert_eq!(result.unwrap(), ctx.base_dir.canonicalize().unwrap());
     }
 
     #[test]
     fn test_resolve_accepts_path_containing_dotdot() {
-        let temp_dir = TempDir::new().unwrap();
-        let sub_dir = temp_dir.path().join("dotdot");
-        fs::create_dir_all(&sub_dir).unwrap();
+        let ctx = TestContext::setup().with_sub_dir();
 
-        let input = sub_dir.join("..").to_str().unwrap().to_string();
-        let result = resolve_project_root(Some(&input), &sub_dir);
+        let input = ctx.base_dir.join("..").to_str().unwrap().to_string();
+        let result = resolve_project_root(Some(&input), &ctx.base_dir);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), temp_dir.path().canonicalize().unwrap());
+        assert_eq!(result.unwrap(), ctx.project_root.canonicalize().unwrap());
     }
 
     #[test]
     fn test_resolve_defaults_to_base_dir_when_none() {
-        let temp_dir = TempDir::new().unwrap();
+        let ctx = TestContext::setup();
 
-        let result = resolve_project_root(None, temp_dir.path());
+        let result = resolve_project_root(None, &ctx.project_root);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), temp_dir.path().canonicalize().unwrap());
+        assert_eq!(result.unwrap(), ctx.project_root.canonicalize().unwrap());
     }
 
     #[test]
     fn test_save_results() {
-        let temp_dir = TempDir::new().unwrap();
-        let project_root = temp_dir.path();
+        let ctx = TestContext::setup();
 
         let output = TddGuardOutput {
             test_modules: vec![],
             reason: Some("passed".to_string()),
         };
 
-        save_results(project_root, &output).unwrap();
+        save_results(&ctx.project_root, &output).unwrap();
 
-        let expected_file = project_root
-            .join(".claude")
-            .join("tdd-guard")
-            .join("data")
-            .join("test.json");
-
-        assert!(expected_file.exists());
-
-        let content = fs::read_to_string(expected_file).unwrap();
-        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
-
-        assert_eq!(parsed["reason"], "passed");
+        assert!(TestContext::test_json_path(&ctx.project_root).exists());
+        assert_eq!(
+            TestContext::read_test_output(&ctx.project_root)["reason"],
+            "passed"
+        );
     }
 
     #[test]
@@ -456,47 +426,24 @@ mod tests {
 
     #[test]
     fn test_process_empty_output() {
-        let temp_dir = TempDir::new().unwrap();
-        let project_root = temp_dir.path();
+        let ctx = TestContext::setup();
 
-        process_output(&[], &[], project_root).unwrap();
+        process_output(&[], &[], &ctx.project_root).unwrap();
 
-        let expected_file = project_root
-            .join(".claude")
-            .join("tdd-guard")
-            .join("data")
-            .join("test.json");
-
-        assert!(expected_file.exists());
+        assert!(TestContext::test_json_path(&ctx.project_root).exists());
     }
 
     #[test]
     fn test_process_output_merges_stderr_compilation_errors_when_no_json() {
-        use tempfile::TempDir;
-        let temp_dir = TempDir::new().unwrap();
-        let project_root = temp_dir.path();
+        let ctx = TestContext::setup();
 
-        // No JSON events, only stderr with a compilation error
-        let test_lines: Vec<String> = vec![
-            // stdout
-            "running 0 tests".to_string(),
-        ];
-        let stderr_lines: Vec<String> = vec![
-            // stderr from rustc
+        let test_lines = vec!["running 0 tests".to_string()];
+        let stderr_lines = vec![
             "error[E0425]: cannot find value `x` in this scope".to_string(),
             " --> src/lib.rs:2:9".to_string(),
         ];
 
-        super::process_output(&test_lines, &stderr_lines, project_root).unwrap();
-
-        // Verify output file exists and contains a compilation module failed
-        let out = project_root
-            .join(".claude")
-            .join("tdd-guard")
-            .join("data")
-            .join("test.json");
-        let content = std::fs::read_to_string(out).unwrap();
-        let v: serde_json::Value = serde_json::from_str(&content).unwrap();
+        let v = ctx.process_and_read(&test_lines, &stderr_lines);
         assert_eq!(v["reason"], "failed");
         assert!(v["testModules"]
             .as_array()
@@ -508,13 +455,9 @@ mod tests {
     #[test]
     fn test_process_passthrough_partitions_json_and_non_json() {
         use crate::parser::TestEvent;
-        use tempfile::TempDir;
 
-        let temp_dir = TempDir::new().unwrap();
-        let project_root = temp_dir.path();
+        let ctx = TestContext::setup();
 
-        // Simulate passthrough partition logic by calling process_output directly with mixed lines.
-        // JSON-like lines need a "type" key to be parsed as events.
         let json_test_event = serde_json::to_string(&TestEvent::Test {
             name: "crate::tests::adds$works".to_string(),
             event: "failed".to_string(),
@@ -523,30 +466,77 @@ mod tests {
         })
         .unwrap();
 
-        let non_json_error = vec![
+        let test_lines = vec![json_test_event];
+        let stderr_lines = vec![
             "error[E0599]: no method named `foo` found for type `u8`".to_string(),
             " --> src/main.rs:10:5".to_string(),
         ];
 
-        let test_lines = vec![json_test_event]; // stdin JSON goes here
-        let stderr_lines = non_json_error; // other lines treated as stderr here
-
-        super::process_output(&test_lines, &stderr_lines, project_root).unwrap();
-
-        let out = project_root
-            .join(".claude")
-            .join("tdd-guard")
-            .join("data")
-            .join("test.json");
-        let content = std::fs::read_to_string(out).unwrap();
-        let v: serde_json::Value = serde_json::from_str(&content).unwrap();
-
-        // Expect both a normal module (crate) and compilation module
+        let v = ctx.process_and_read(&test_lines, &stderr_lines);
         assert_eq!(v["reason"], "failed");
         let modules = v["testModules"].as_array().unwrap();
         assert!(modules
             .iter()
             .any(|m| m["moduleId"].as_str().unwrap().contains("crate")));
         assert!(modules.iter().any(|m| m["moduleId"] == "compilation"));
+    }
+
+    // Test helpers
+
+    struct TestContext {
+        project_root: PathBuf,
+        base_dir: PathBuf,
+        _temp_dir: TempDir,
+    }
+
+    impl TestContext {
+        fn setup() -> Self {
+            let temp_dir = TempDir::new().unwrap();
+            let project_root = temp_dir.path().to_path_buf();
+            let base_dir = project_root.clone();
+            Self {
+                project_root,
+                base_dir,
+                _temp_dir: temp_dir,
+            }
+        }
+
+        fn with_sub_dir(mut self) -> Self {
+            let sub_dir = self.project_root.join("sub");
+            fs::create_dir_all(&sub_dir).unwrap();
+            self.base_dir = sub_dir;
+            self
+        }
+
+        fn test_json_path(root: &Path) -> PathBuf {
+            root.join(".claude")
+                .join("tdd-guard")
+                .join("data")
+                .join("test.json")
+        }
+
+        fn read_test_output(root: &Path) -> serde_json::Value {
+            let content = fs::read_to_string(Self::test_json_path(root)).unwrap();
+            serde_json::from_str(&content).unwrap()
+        }
+
+        fn process_and_read(
+            &self,
+            test_lines: &[String],
+            stderr_lines: &[String],
+        ) -> serde_json::Value {
+            process_output(test_lines, stderr_lines, &self.project_root).unwrap();
+            Self::read_test_output(&self.project_root)
+        }
+
+        fn make_args(project_root: Option<&str>) -> Args {
+            Args {
+                project_root: project_root.map(|s| s.to_string()),
+                passthrough: true,
+                no_auto_passthrough: true,
+                runner: "auto".to_string(),
+                test_args: vec![],
+            }
+        }
     }
 }

--- a/reporters/rust/src/main.rs
+++ b/reporters/rust/src/main.rs
@@ -249,7 +249,7 @@ fn detect_runner(preference: &str) -> String {
         "auto" => {
             // Check if nextest is available (cache this in real impl)
             if Command::new("cargo")
-                .args(&["nextest", "--version"])
+                .args(["nextest", "--version"])
                 .output()
                 .map(|output| output.status.success())
                 .unwrap_or(false)

--- a/reporters/rust/src/transformer.rs
+++ b/reporters/rust/src/transformer.rs
@@ -6,21 +6,12 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// TDD Guard output format
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct TddGuardOutput {
     #[serde(rename = "testModules")]
     pub test_modules: Vec<TestModule>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
-}
-
-impl Default for TddGuardOutput {
-    fn default() -> Self {
-        Self {
-            test_modules: Vec::new(),
-            reason: None,
-        }
-    }
 }
 
 impl TddGuardOutput {
@@ -110,7 +101,6 @@ pub fn transform_events(
 
     // Process test events
     let mut has_test_failure = false;
-    let mut has_test_pass = false;
 
     for event in events {
         if let TestEvent::Test {
@@ -123,10 +113,7 @@ pub fn transform_events(
             let simple_name = event.simple_test_name();
 
             let state = match event_type.as_str() {
-                "ok" => {
-                    has_test_pass = true;
-                    "passed"
-                }
+                "ok" => "passed",
                 "failed" => {
                     has_test_failure = true;
                     "failed"
@@ -153,8 +140,6 @@ pub fn transform_events(
     // Determine overall reason with simple priority
     let reason = if modules.contains_key("compilation") || has_test_failure {
         "failed"
-    } else if has_test_pass || !modules.is_empty() {
-        "passed"
     } else {
         "passed"
     };
@@ -269,7 +254,7 @@ fn extract_assertion_details(message: &str) -> (String, Option<String>, Option<S
         }
 
         let main_message = lines
-            .get(0)
+            .first()
             .map(|s| s.to_string())
             .unwrap_or_else(|| message.to_string());
 


### PR DESCRIPTION
## Summary

The Rust reporter no longer requires an absolute path for `--project-root`, and the flag itself is now optional. Relative paths and paths containing `..` are resolved against the current working directory. The reporter now reads `TDD_GUARD_PROJECT_ROOT` as a fallback and errors when no project root is configured.

## Details

- The project root is now resolved rather than validated. `std::fs::canonicalize` handles absolute, relative, and `..` paths uniformly, replacing the previous `is_absolute` and `exists` checks in `main()`.
- `TDD_GUARD_PROJECT_ROOT` environment variable is read when no `--project-root` flag is provided. When neither is configured, the reporter errors with a descriptive message.
- `main()` logic is extracted into a testable `run(args, base_dir)` function. `base_dir` is injected so tests use isolated temp dirs without global cwd mutation, allowing parallel execution.
- A `TestContext` struct consolidates repeated test setup — temp dir creation, path construction, file reading, and JSON parsing — into a builder with helpers at the bottom of the test file.
- Pre-existing clippy warnings and formatting issues across the reporter are resolved in dedicated commits.

## Notes
- The rationale for the relaxation is recorded in [ADR-009](docs/adr/009-relax-reporter-project-root-validation.md) and [ADR-010](docs/adr/010-standardize-project-root-env-var.md).