### PR TITLE
feat(minitest): add unhandledErrors field to test.json output

### DIFF
--- a/reporters/minitest/lib/minitest/tdd_guard_plugin.rb
+++ b/reporters/minitest/lib/minitest/tdd_guard_plugin.rb
@@ -4,6 +4,11 @@ require "tdd_guard_minitest/reporter"
 
 module Minitest
   def self.plugin_tdd_guard_init(options)
+    # Guard against double initialization. In Minitest 5, load_plugins
+    # may register "tdd_guard" in extensions even when autorun.rb has
+    # already done so, causing init_plugins to call this method twice.
+    return if reporter.reporters.any? { |r| r.is_a?(TddGuardMinitest::Reporter) }
+
     reporter << TddGuardMinitest::Reporter.new(options[:io], options)
   end
 end

--- a/reporters/minitest/lib/tdd_guard_minitest/autorun.rb
+++ b/reporters/minitest/lib/tdd_guard_minitest/autorun.rb
@@ -1,13 +1,25 @@
 # frozen_string_literal: true
 
 # Entry point used to guarantee that the tdd-guard-minitest reporter is in
-# place before the user's test file is loaded. Loading Minitest::Autorun
-# here registers Minitest's own at_exit hook, and the at_exit block below
-# is registered *after* it, which means it fires *before* Minitest's hook
-# in LIFO order. That lets us intercept unhandled exceptions raised while
-# loading the user's test file (typically a LoadError from a missing
-# require) and write a synthetic failed test to test.json so the
-# validation agent can see that a test tried to run and failed.
+# place before the user's test file is loaded.
+#
+# Three hooks are registered here, ordered by when they *fire* (LIFO):
+#
+# 1. Load-error at_exit (registered last, fires first):
+#    Intercepts unhandled exceptions raised while loading the user's test
+#    file (typically a LoadError from a missing require).
+#
+# 2. Minitest's own at_exit hooks (registered by require "minitest/autorun"):
+#    Outer hook runs tests and calls reporter.report.
+#    Inner hook (registered during the outer hook) runs after_run blocks.
+#
+# 3. Post-after_run at_exit (registered first, fires last):
+#    If any wrapped after_run blocks raised, patches test.json with the
+#    captured unhandledErrors.
+#
+# Between hooks 1 and 3, Minitest.after_run is patched so that each
+# user-registered block is wrapped in a begin/rescue that captures
+# exceptions into TddGuardMinitest.unhandled_errors before re-raising.
 #
 # Usage:
 #
@@ -17,9 +29,44 @@
 #
 #   require "tdd_guard_minitest/autorun"
 
-require "minitest/autorun"
 require "tdd_guard_minitest/reporter"
 
+# Hook 3 (fires last): patch test.json with any captured after_run errors.
+# Registered before Minitest's at_exit so it fires after all Minitest hooks.
+at_exit do
+  errors = TddGuardMinitest.unhandled_errors
+  next if errors.empty?
+
+  TddGuardMinitest::Reporter.append_unhandled_errors(errors)
+end
+
+require "minitest/autorun"
+
+# Ensure the plugin is registered even when Minitest does not call
+# load_plugins automatically (Minitest 6+). In Minitest 5, load_plugins
+# is called during Minitest.run and discovers the plugin via
+# Gem.find_files; this explicit registration is harmless in that case
+# because init_plugins skips duplicate names.
+require "minitest/tdd_guard_plugin"
+Minitest.extensions << "tdd_guard" unless Minitest.extensions.include?("tdd_guard")
+
+# Wrap Minitest.after_run so that each block registered by user code or
+# plugins is intercepted. Captured exceptions are stored for the post-
+# after_run at_exit hook above while still re-raising to preserve
+# Minitest's default behavior.
+original_after_run = Minitest.method(:after_run)
+Minitest.define_singleton_method(:after_run) do |&block|
+  original_after_run.call do
+    begin
+      block.call
+    rescue Exception => e # rubocop:disable Lint/RescueException
+      TddGuardMinitest.unhandled_errors << e unless e.is_a?(SystemExit)
+      raise
+    end
+  end
+end
+
+# Hook 1 (fires first): capture load errors before Minitest runs.
 at_exit do
   exc = $!
   next if exc.nil?

--- a/reporters/minitest/lib/tdd_guard_minitest/reporter.rb
+++ b/reporters/minitest/lib/tdd_guard_minitest/reporter.rb
@@ -5,6 +5,12 @@ require "fileutils"
 require "minitest"
 
 module TddGuardMinitest
+  @unhandled_errors = []
+
+  class << self
+    attr_reader :unhandled_errors
+  end
+
   # Minitest reporter that captures test results for TDD Guard validation.
   # Mirrors the RSpec reporter's single-class architecture.
   class Reporter < Minitest::StatisticsReporter
@@ -32,6 +38,22 @@ module TddGuardMinitest
     # to avoid clobbering real results.
     def self.handle_load_error(exception)
       new(StringIO.new).handle_load_error(exception)
+    end
+
+    # Reads the existing test.json, merges in the unhandledErrors field,
+    # and re-writes it. Called from the post-after_run at_exit hook in
+    # autorun.rb after Minitest.after_run blocks have completed.
+    def self.append_unhandled_errors(errors)
+      new(StringIO.new).append_unhandled_errors(errors)
+    end
+
+    def append_unhandled_errors(errors)
+      json_path = File.join(@storage_dir, "test.json")
+      return unless File.exist?(json_path)
+
+      data = JSON.parse(File.read(json_path))
+      data["unhandledErrors"] = errors.map { |e| build_unhandled_error(e) }
+      File.write(json_path, JSON.pretty_generate(data))
     end
 
     def handle_load_error(exception)
@@ -104,6 +126,14 @@ module TddGuardMinitest
           klass.runnable_methods.size
         end
       end
+    end
+
+    def build_unhandled_error(exception)
+      name = exception.class.name || "(anonymous error class)"
+      error = { "name" => name, "message" => exception.message }
+      stack = extract_relevant_stack(exception.backtrace)
+      error["stack"] = stack if stack
+      error
     end
 
     def build_error(failure)

--- a/reporters/minitest/spec/reporter_spec.rb
+++ b/reporters/minitest/spec/reporter_spec.rb
@@ -557,6 +557,142 @@ RSpec.describe TddGuardMinitest::Reporter do
     end
   end
 
+  describe "unhandledErrors field" do
+    it "builds an unhandled error with name, message, and stack" do
+      Dir.mktmpdir do |tmpdir|
+        create_reporter_in(tmpdir) do |reporter, storage_dir|
+          reporter.record(build_result(name: "test_passes"))
+          reporter.report
+
+          exc = RuntimeError.new("cleanup failed")
+          exc.set_backtrace([
+            "./test/my_class_test.rb:4:in `block (2 levels) in <top (required)>'",
+            "/path/to/gems/minitest-5.27.0/lib/minitest.rb:10:in `run'"
+          ])
+          reporter.append_unhandled_errors([exc])
+
+          data = JSON.parse(File.read(File.join(storage_dir, default_data_dir, "test.json")))
+          expect(data).to have_key("unhandledErrors")
+          expect(data["unhandledErrors"].length).to eq(1)
+
+          entry = data["unhandledErrors"][0]
+          expect(entry["name"]).to eq("RuntimeError")
+          expect(entry["message"]).to eq("cleanup failed")
+          expect(entry["stack"]).to eq("test/my_class_test.rb:4:in `block (2 levels) in <top (required)>'")
+        end
+      end
+    end
+
+    it "handles namespaced exception class" do
+      Dir.mktmpdir do |tmpdir|
+        create_reporter_in(tmpdir) do |reporter, storage_dir|
+          reporter.report
+
+          mod = Module.new
+          # Define a named class inside the module for class.name to work
+          stub_const("MyApp::DatabaseError", Class.new(StandardError))
+          exc = MyApp::DatabaseError.new("connection lost")
+          exc.set_backtrace(["./test/db_test.rb:10:in `test_query'"])
+          reporter.append_unhandled_errors([exc])
+
+          data = JSON.parse(File.read(File.join(storage_dir, default_data_dir, "test.json")))
+          expect(data["unhandledErrors"][0]["name"]).to eq("MyApp::DatabaseError")
+        end
+      end
+    end
+
+    it "falls back to anonymous name when exception class has no name" do
+      Dir.mktmpdir do |tmpdir|
+        create_reporter_in(tmpdir) do |reporter, storage_dir|
+          reporter.report
+
+          anon_class = Class.new(StandardError)
+          exc = anon_class.new("anonymous failure")
+          exc.set_backtrace(["./test/anon_test.rb:5:in `test_it'"])
+          reporter.append_unhandled_errors([exc])
+
+          data = JSON.parse(File.read(File.join(storage_dir, default_data_dir, "test.json")))
+          expect(data["unhandledErrors"][0]["name"]).to eq("(anonymous error class)")
+        end
+      end
+    end
+
+    it "omits stack when backtrace is nil" do
+      Dir.mktmpdir do |tmpdir|
+        create_reporter_in(tmpdir) do |reporter, storage_dir|
+          reporter.report
+
+          exc = RuntimeError.new("no trace")
+          reporter.append_unhandled_errors([exc])
+
+          data = JSON.parse(File.read(File.join(storage_dir, default_data_dir, "test.json")))
+          expect(data["unhandledErrors"][0]).not_to have_key("stack")
+        end
+      end
+    end
+
+    it "omits stack when backtrace has only gem frames" do
+      Dir.mktmpdir do |tmpdir|
+        create_reporter_in(tmpdir) do |reporter, storage_dir|
+          reporter.report
+
+          exc = RuntimeError.new("gem-only trace")
+          exc.set_backtrace([
+            "/path/to/gems/minitest-5.27.0/lib/minitest.rb:10:in `run'"
+          ])
+          reporter.append_unhandled_errors([exc])
+
+          data = JSON.parse(File.read(File.join(storage_dir, default_data_dir, "test.json")))
+          expect(data["unhandledErrors"][0]).not_to have_key("stack")
+        end
+      end
+    end
+
+    it "writes all errors when given multiple exceptions" do
+      Dir.mktmpdir do |tmpdir|
+        create_reporter_in(tmpdir) do |reporter, storage_dir|
+          reporter.report
+
+          errors = %w[first second].map do |msg|
+            exc = RuntimeError.new(msg)
+            exc.set_backtrace(["./test/multi_test.rb:3:in `test_it'"])
+            exc
+          end
+          reporter.append_unhandled_errors(errors)
+
+          data = JSON.parse(File.read(File.join(storage_dir, default_data_dir, "test.json")))
+          expect(data["unhandledErrors"].length).to eq(2)
+          expect(data["unhandledErrors"][0]["message"]).to eq("first")
+          expect(data["unhandledErrors"][1]["message"]).to eq("second")
+        end
+      end
+    end
+
+    it "does not add unhandledErrors key when no errors exist" do
+      Dir.mktmpdir do |tmpdir|
+        create_reporter_in(tmpdir) do |reporter, storage_dir|
+          reporter.record(build_result(name: "test_passes"))
+          data = run_and_read_json(reporter, storage_dir)
+
+          expect(data).not_to have_key("unhandledErrors")
+        end
+      end
+    end
+
+    it "does not patch test.json when it does not exist" do
+      Dir.mktmpdir do |tmpdir|
+        create_reporter_in(tmpdir) do |reporter, storage_dir|
+          # Do not call report, so test.json does not exist
+          exc = RuntimeError.new("orphan error")
+          reporter.append_unhandled_errors([exc])
+
+          json_path = File.join(storage_dir, default_data_dir, "test.json")
+          expect(File.exist?(json_path)).to be false
+        end
+      end
+    end
+  end
+
   describe ".handle_load_error" do
     # Helper: run handle_load_error in an isolated tmpdir and return parsed JSON
     def run_handle_load_error_in(tmpdir, exception)

--- a/reporters/minitest/spec/unhandled_errors_integration_spec.rb
+++ b/reporters/minitest/spec/unhandled_errors_integration_spec.rb
@@ -8,27 +8,27 @@ require "open3"
 require "rbconfig"
 
 # Integration test that runs a real Ruby process end-to-end to verify that
-# the at_exit hook in lib/tdd_guard_minitest/autorun.rb captures load errors
-# correctly.
+# the autorun.rb hooks capture after_run block exceptions as unhandledErrors
+# in test.json.
 #
-# This test exists to detect regressions if Minitest or Ruby changes the
-# ordering semantics of at_exit blocks or the visibility of $! during
-# process teardown. A failure here signals that the load-error capture
-# path is broken end-to-end, even if the unit specs still pass.
-RSpec.describe "load error integration" do
+# This test exists to detect regressions if Minitest changes the at_exit
+# ordering or after_run execution semantics. A failure here signals that
+# the unhandled-error capture path is broken end-to-end, even if the unit
+# specs still pass.
+RSpec.describe "unhandled errors integration" do
   let(:repo_lib) { File.expand_path("../lib", __dir__) }
 
   def run_minitest(tmpdir, test_body)
     test_dir = File.join(tmpdir, "test")
     FileUtils.mkdir_p(test_dir)
-    File.write(File.join(test_dir, "load_error_test.rb"), test_body)
+    File.write(File.join(test_dir, "after_run_test.rb"), test_body)
 
     env = { "TDD_GUARD_PROJECT_ROOT" => tmpdir }
     cmd = [
       RbConfig.ruby,
       "-I", repo_lib,
       "-rtdd_guard_minitest/autorun",
-      "test/load_error_test.rb"
+      "test/after_run_test.rb"
     ]
     Open3.capture3(env, *cmd, chdir: tmpdir)
 
@@ -37,10 +37,11 @@ RSpec.describe "load error integration" do
     JSON.parse(File.read(json_path))
   end
 
-  it "captures a LoadError from a real ruby process" do
+  it "captures an after_run error from a real ruby process" do
     test_body = <<~RUBY
-      require "non_existent_module"
       require "minitest/autorun"
+
+      Minitest.after_run { raise RuntimeError, "after_run cleanup failed" }
 
       class CalculatorTest < Minitest::Test
         def test_should_add
@@ -53,21 +54,25 @@ RSpec.describe "load error integration" do
       data = run_minitest(tmpdir, test_body)
 
       expect(data).not_to be_nil,
-        "test.json was not written -- at_exit ordering or $! visibility may have changed"
-      expect(data["reason"]).to eq("failed")
-      expect(data["testModules"].length).to eq(1)
+        "test.json was not written -- at_exit ordering may have changed"
+      expect(data).to have_key("unhandledErrors"),
+        "unhandledErrors missing -- after_run error capture may be broken"
 
-      test = data["testModules"][0]["tests"][0]
-      expect(test["state"]).to eq("failed")
-      expect(test["name"]).to include("LoadError")
-      expect(test["name"]).to include("non_existent_module")
-      expect(test["errors"][0]["message"]).to include("load_error_test.rb")
+      entry = data["unhandledErrors"].first
+      expect(entry["name"]).to eq("RuntimeError")
+      expect(entry["message"]).to eq("after_run cleanup failed")
+
+      # Tests themselves should still appear as passed
+      tests = data["testModules"].flat_map { |m| m["tests"] }
+      expect(tests[0]["state"]).to eq("passed")
     end
   end
 
-  it "does not write a synthetic failure when the test file loads cleanly" do
+  it "does not add unhandledErrors when after_run succeeds" do
     test_body = <<~RUBY
       require "minitest/autorun"
+
+      Minitest.after_run { $stdout.puts "clean teardown" }
 
       class CalculatorTest < Minitest::Test
         def test_should_add
@@ -80,8 +85,9 @@ RSpec.describe "load error integration" do
       data = run_minitest(tmpdir, test_body)
 
       expect(data).not_to be_nil, "test.json should still be written via the normal report path"
+      expect(data).not_to have_key("unhandledErrors")
+
       tests = data["testModules"].flat_map { |m| m["tests"] }
-      expect(tests.map { |t| t["name"] }).to eq(["test_should_add"])
       expect(tests[0]["state"]).to eq("passed")
     end
   end

--- a/reporters/test/artifacts/minitest/after_run_error_test.rb
+++ b/reporters/test/artifacts/minitest/after_run_error_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Test artifact: registers a Minitest.after_run block that raises an error.
+# Used by the unhandled errors integration test to verify that exceptions
+# from after_run blocks are captured in test.json as unhandledErrors.
+
+require "minitest/autorun"
+
+Minitest.after_run { raise RuntimeError, "after_run cleanup failed" }
+
+class CalculatorTest < Minitest::Test
+  def test_should_add
+    assert_equal 5, 2 + 3
+  end
+end


### PR DESCRIPTION
## Summary

- Capture exceptions from `Minitest.after_run` blocks by wrapping each registered block in a `begin/rescue` that stores errors in a module-level array before re-raising
- Patch test.json with the captured `unhandledErrors` array via a post-after_run `at_exit` hook that fires after all Minitest hooks complete
- Guard against double plugin registration in Minitest 5 where `load_plugins` may add the extension a second time
- Explicitly register the plugin for Minitest 6+ where `load_plugins` is no longer called automatically
- Fix integration tests to use `RbConfig.ruby` instead of `bundle exec ruby` so child processes use the correct Ruby interpreter
- Add 8 unit tests and 2 end-to-end integration tests, plus a test artifact

Minitest has no equivalent to RSpec's `:message` callback, so errors outside individual test methods cannot be collected during the reporter lifecycle. The `autorun.rb` entry point registers three `at_exit` hooks in a specific order to exploit Ruby's LIFO semantics: (1) load-error capture fires first, (2) Minitest runs tests and after_run blocks, (3) our post-hook patches test.json with any captured errors. Only one after_run error can be captured per run because Minitest's `@@after_run.reverse_each` stops at the first exception.

Closes #148
Follow-up from #145. cc @nizos

## Test plan

- [ ] `cd reporters/minitest && bundle exec rspec` -- all tests pass
- [ ] unhandledErrors: after_run exceptions recorded in test.json (2 integration tests)
- [ ] No unhandledErrors key when no errors occur