### PR TITLE
feat(minitest): detect interrupted test runs

### DIFF
--- a/reporters/minitest/lib/tdd_guard_minitest/reporter.rb
+++ b/reporters/minitest/lib/tdd_guard_minitest/reporter.rb
@@ -13,7 +13,13 @@ module TddGuardMinitest
     def initialize(io = $stdout, options = {})
       super
       @test_results = []
+      @expected_count = 0
       @storage_dir = determine_storage_dir
+    end
+
+    def start
+      super
+      @expected_count = compute_expected_count
     end
 
     # Writes a synthetic failed-test JSON for an exception raised before
@@ -67,9 +73,16 @@ module TddGuardMinitest
       end
 
       has_failures = @test_results.any? { |t| t["state"] == "failed" }
+      reason = if has_failures
+                 "failed"
+               elsif @expected_count > 0 && @test_results.length < @expected_count
+                 "interrupted"
+               else
+                 "passed"
+               end
       result = {
         "testModules" => modules_map.values,
-        "reason" => has_failures ? "failed" : "passed"
+        "reason" => reason
       }
 
       FileUtils.mkdir_p(@storage_dir)
@@ -81,6 +94,17 @@ module TddGuardMinitest
     end
 
     private
+
+    def compute_expected_count
+      filter = options[:filter]
+      Minitest::Runnable.runnables.sum do |klass|
+        if filter
+          klass.methods_matching(filter).size
+        else
+          klass.runnable_methods.size
+        end
+      end
+    end
 
     def build_error(failure)
       if failure.is_a?(Minitest::UnexpectedError)

--- a/reporters/minitest/spec/reporter_spec.rb
+++ b/reporters/minitest/spec/reporter_spec.rb
@@ -208,6 +208,86 @@ RSpec.describe TddGuardMinitest::Reporter do
         end
       end
     end
+
+    it "reports interrupted when fewer results than expected" do
+      Dir.mktmpdir do |tmpdir|
+        create_reporter_in(tmpdir) do |reporter, storage_dir|
+          reporter.instance_variable_set(:@expected_count, 5)
+
+          %w[test_one test_two].each do |name|
+            reporter.record(
+              build_result(
+                name: name,
+                klass: "MyClassTest",
+                source_location: ["./test/my_class_test.rb", 5]
+              )
+            )
+          end
+
+          data = run_and_read_json(reporter, storage_dir)
+          expect(data["reason"]).to eq("interrupted")
+        end
+      end
+    end
+
+    it "reports failed not interrupted when failures exist with fewer results" do
+      Dir.mktmpdir do |tmpdir|
+        create_reporter_in(tmpdir) do |reporter, storage_dir|
+          reporter.instance_variable_set(:@expected_count, 5)
+
+          reporter.record(
+            build_result(
+              name: "test_passes",
+              klass: "MyClassTest",
+              source_location: ["./test/my_class_test.rb", 5]
+            )
+          )
+          reporter.record(
+            build_result(
+              name: "test_fails",
+              klass: "MyClassTest",
+              source_location: ["./test/my_class_test.rb", 10],
+              failures: [build_assertion_failure(message: "expected true")]
+            )
+          )
+
+          data = run_and_read_json(reporter, storage_dir)
+          expect(data["reason"]).to eq("failed")
+        end
+      end
+    end
+
+    it "reports passed when all expected tests complete" do
+      Dir.mktmpdir do |tmpdir|
+        create_reporter_in(tmpdir) do |reporter, storage_dir|
+          reporter.instance_variable_set(:@expected_count, 2)
+
+          %w[test_one test_two].each do |name|
+            reporter.record(
+              build_result(
+                name: name,
+                klass: "MyClassTest",
+                source_location: ["./test/my_class_test.rb", 5]
+              )
+            )
+          end
+
+          data = run_and_read_json(reporter, storage_dir)
+          expect(data["reason"]).to eq("passed")
+        end
+      end
+    end
+
+    it "reports passed when expected count is zero" do
+      Dir.mktmpdir do |tmpdir|
+        create_reporter_in(tmpdir) do |reporter, storage_dir|
+          reporter.instance_variable_set(:@expected_count, 0)
+
+          data = run_and_read_json(reporter, storage_dir)
+          expect(data["reason"]).to eq("passed")
+        end
+      end
+    end
   end
 
   describe "stack field" do


### PR DESCRIPTION
## Summary

- Detect interrupted test runs by comparing expected test count with actual results in `report()`
- Compute expected count from `Minitest::Runnable.runnables` in `start`, applying `options[:filter]` for `--name` restricted runs
- Add 4 unit tests mirroring the RSpec reporter's interrupted detection tests

Mirrors the RSpec reporter's count-comparison approach (#129). Signal-based interruption (Ctrl+C) is deferred per discussion in #149 -- the `at_exit` extension can be a follow-up if needed.

With this change (and #148), the minitest reporter reaches feature parity with the RSpec reporter.

Closes #149
cc @nizos

## Test plan

- [ ] `cd reporters/minitest && bundle exec rspec spec/reporter_spec.rb` -- 36 tests pass
- [ ] `reason: "interrupted"` when expected > actual
- [ ] `reason: "failed"` takes precedence over interrupted when failures exist
- [ ] `reason: "passed"` when expected == actual or expected == 0