### PR TITLE
docs: add Minitest to supported frameworks and contributors list

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ TDD Guard ensures Claude Code follows Test-Driven Development principles. When y
 ### Requirements
 
 - Node.js 22+
-- A supported test framework (Vitest, Jest, Storybook, pytest, PHPUnit, Go, Rust, RSpec)
+- A supported test framework (Vitest, Jest, Storybook, pytest, PHPUnit, Go, Rust, RSpec, Minitest)
 
 ### Installation
 
@@ -72,7 +72,7 @@ Contributions are welcome! See the [contributing guidelines](CONTRIBUTING.md) to
 - Rust/cargo support: [@104hp6u](https://github.com/104hp6u)
 - Go support: [@sQVe](https://github.com/sQVe), [@wizzomafizzo](https://github.com/wizzomafizzo)
 - Storybook support: [@akornmeier](https://github.com/akornmeier)
-- Ruby/RSpec support: [@Hiro-Chiba](https://github.com/Hiro-Chiba)
+- Ruby/RSpec & Minitest support: [@Hiro-Chiba](https://github.com/Hiro-Chiba)
 
 ### Roadmap
 


### PR DESCRIPTION
## Summary

Add Minitest to the README now that the reporter has reached feature parity with the RSpec reporter:

- Line 37: Add `Minitest` to the list of supported test frameworks
- Line 75: Update the contributors entry to `Ruby/RSpec & Minitest support`

## Context

- #158 merged: interrupted detection
- #157 pending: unhandledErrors field

Together these complete the Minitest reporter's feature set. This docs-only PR finalizes Minitest's position as an officially supported framework in the README.

cc @nizos