### PR TITLE
fix(guard): ignore ERB templates by default

### DIFF
--- a/docs/ignore-patterns.md
+++ b/docs/ignore-patterns.md
@@ -18,6 +18,7 @@ By default, TDD Guard ignores files with these extensions:
 - `*.xml` - XML files
 - `*.html` - HTML files
 - `*.css` - Stylesheets
+- `*.erb` - Rails ERB templates
 - `*.rst` - reStructuredText documentation
 
 ## Custom Ignore Patterns

--- a/src/guard/GuardManager.test.ts
+++ b/src/guard/GuardManager.test.ts
@@ -319,6 +319,12 @@ describe('GuardManager', () => {
         expect(await guardManager.shouldIgnoreFile(path)).toBe(shouldIgnore)
       })
     })
+
+    it('ignores ERB templates by default', async () => {
+      expect(
+        await guardManager.shouldIgnoreFile('app/views/users/show.html.erb')
+      ).toBe(true)
+    })
   })
 })
 

--- a/src/guard/GuardManager.ts
+++ b/src/guard/GuardManager.ts
@@ -24,6 +24,7 @@ export class GuardManager {
     '*.xml',
     '*.html',
     '*.css',
+    '*.erb',
     '*.rst',
   ]
 


### PR DESCRIPTION
## Summary

Add `*.erb` to the default ignore patterns so Rails view templates are skipped out of the box.

- update `GuardManager.DEFAULT_IGNORE_PATTERNS`
- add a regression test for `app/views/users/show.html.erb`
- document the new default in `docs/ignore-patterns.md`

Closes #163

## Test plan

- [x] `npm run build:workspaces`
- [x] `npx vitest run --project unit src/guard/GuardManager.test.ts`
- [x] `npm run format:check`
- [x] `npm run lint:check`
- [x] `npm run typecheck`
- [x] `npm run build`
