### PR TITLE
fix(cli): suppress stdout for non-actionable validation results

### DIFF
--- a/src/cli/tdd-guard.test.ts
+++ b/src/cli/tdd-guard.test.ts
@@ -35,6 +35,22 @@ describe('tdd-guard CLI', () => {
 
       expect(stderr).toContain('Failed to parse hook data')
     })
+
+    test('emits no stdout when result has no actionable decision', async () => {
+      // `defaultResult` serializes to `{"reason":""}` (JSON.stringify drops
+      // undefined), which Claude Code's UserPromptSubmit hook reads as a
+      // decision payload and uses to silently consume the user's prompt -
+      // including built-in slash commands like `/clear`.
+      const noopHookInput = JSON.stringify({
+        hook_event_name: 'UserPromptSubmit',
+        prompt: 'hello',
+      })
+
+      const { stdout, exitCode } = await runCli(noopHookInput)
+
+      expect(stdout).toBe('')
+      expect(exitCode).toBe(0)
+    })
   })
 
   describe('Data Persistence', () => {

--- a/src/cli/tdd-guard.ts
+++ b/src/cli/tdd-guard.ts
@@ -38,7 +38,13 @@ if (require.main === module) {
   process.stdin.on('end', async () => {
     try {
       const result = await run(inputData)
-      console.log(JSON.stringify(result))
+      if (
+        result.decision !== undefined ||
+        result.reason !== '' ||
+        result.continue === false
+      ) {
+        console.log(JSON.stringify(result))
+      }
     } catch (error) {
       console.error('Failed to parse hook data:', error)
     } finally {


### PR DESCRIPTION
Fixes #166.

## Why

`JSON.stringify({decision: undefined, reason: ''})` produces `{"reason":""}` because `JSON.stringify` drops undefined values. Claude Code's `UserPromptSubmit` hook protocol parses any non-empty stdout as a hook decision payload, so emitting `{"reason":""}` for the default no-op path silently consumes the user's prompt — including built-in slash commands like `/clear`, which "flash and return with nothing" instead of starting a new conversation.

Full context, repro, and affected versions in #166.

## What

Only emit on stdout when the result carries an actionable signal:

- `decision` is set, OR
- `reason` is non-empty, OR
- `continue` is `false`

The hook-protocol contract for "no decision" is empty stdout, not an empty object.

## Test

Added `emits no stdout when result has no actionable decision` to `src/cli/tdd-guard.test.ts`. RED before the fix (`expect(stdout).toBe('')` saw `{"reason":""}\n`), GREEN after.

The existing `tdd-guard on` / `tdd-guard off` paths still emit because they set `continue: false` — verified by the existing tests in `userPromptHandler.test.ts` plus a manual check.

## Checks

- `npm run typecheck` — clean
- `npm run lint:check` — clean
- `npm run format:check` — clean
- `npx vitest run src/cli/ src/hooks/ --project default --project unit` — 294/294 passing (CLI + hooks scope)

The 7 pre-existing unit-test failures elsewhere (`src/linters/golangci/*`, `src/linters/rubocop/*`) are environment-dependent integration tests that need Go/Ruby toolchains; they fail identically on `main` HEAD without my change.

## Single concern

Per CONTRIBUTING: this PR addresses the one bug. No unrelated refactoring or formatting changes.