### PR TITLE
docs: add minitest reporter to CLAUDE.md project structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ The codebase is organized with core functionality in src/ and language-specific 
 reporters/                        # Language-specific test reporters
 ├── go/                           # tdd-guard-go - Go test reporter
 ├── jest/                         # tdd-guard-jest - Jest reporter (npm)
+├── minitest/                     # tdd-guard-minitest - Minitest reporter (gem)
 ├── phpunit/                      # tdd-guard/phpunit - PHPUnit reporter (composer)
 ├── pytest/                       # tdd-guard-pytest - Pytest reporter (pip)
 ├── rspec/                        # tdd-guard-rspec - RSpec reporter (gem)
@@ -66,7 +67,7 @@ docs/                             # Documentation (ADRs, configuration, etc.)
 TDD Guard is organized as a TypeScript project with integrated language-specific reporters:
 
 - **src/**: Core functionality including contracts, config, storage, and validation
-- **reporters/**: Language-specific test reporters (go, jest, phpunit, pytest, rspec, rust, storybook, vitest)
+- **reporters/**: Language-specific test reporters (go, jest, minitest, phpunit, pytest, rspec, rust, storybook, vitest)
 - **test/**: Comprehensive test suite with integration tests and utilities
 
 ### Testing


### PR DESCRIPTION
## Summary

- The minitest reporter was added under `reporters/minitest/` but `CLAUDE.md` was not updated to list it, leaving the project structure section out of sync with the actual codebase.
- `README.md` already documents minitest as a supported framework and credits its contributor, so aligning `CLAUDE.md` keeps onboarding context consistent across docs.
- This follows the same pattern as `b66d94b docs: update CLAUDE.md project structure with missing reporters`.

## Changes

- Added `minitest/` entry in the reporters tree.
- Added `minitest` to the `reporters/` summary bullet under Architecture.

## Out of scope

- JUnit5 reporter is intentionally excluded from this PR. It can be added once the implementation is fully landed and stable.

## Test plan

- [x] Verified `git diff` only touches `CLAUDE.md` (2 insertions, 1 deletion).
- [x] Confirmed no other docs or build files reference the previous list shape.