### PR TITLE
feat(rspec, minitest): relax project root path validation

### DIFF
--- a/reporters/minitest/README.md
+++ b/reporters/minitest/README.md
@@ -60,9 +60,9 @@ export TDD_GUARD_PROJECT_ROOT="/absolute/path/to/project/root"
 
 ### Configuration Rules
 
-- Path must be absolute
-- Current directory must be within the configured project root
-- Falls back to current directory if configuration is invalid
+- Set `TDD_GUARD_PROJECT_ROOT` to the project root. Absolute and relative paths are both accepted; relative paths resolve against the working directory at runtime.
+- Tests must be run from a directory at or below the project root.
+- The reporter raises at startup when the variable is not set. It no longer silently falls back to the current directory.
 
 ## Development
 

--- a/reporters/minitest/lib/tdd_guard_minitest/reporter.rb
+++ b/reporters/minitest/lib/tdd_guard_minitest/reporter.rb
@@ -38,6 +38,10 @@ module TddGuardMinitest
     # to avoid clobbering real results.
     def self.handle_load_error(exception)
       new(StringIO.new).handle_load_error(exception)
+    rescue ArgumentError
+      # Project root is not configured; the user has already seen the
+      # configuration error from the main test run. Avoid double-raising
+      # from the autorun at_exit hook.
     end
 
     # Reads the existing test.json, merges in the unhandledErrors field,
@@ -45,6 +49,8 @@ module TddGuardMinitest
     # autorun.rb after Minitest.after_run blocks have completed.
     def self.append_unhandled_errors(errors)
       new(StringIO.new).append_unhandled_errors(errors)
+    rescue ArgumentError
+      # Same as above: skip when the project root is not configured.
     end
 
     def append_unhandled_errors(errors)
@@ -173,21 +179,31 @@ module TddGuardMinitest
 
     def determine_storage_dir
       project_root = ENV["TDD_GUARD_PROJECT_ROOT"]
-      return DEFAULT_DATA_DIR unless project_root && !project_root.empty?
-      return DEFAULT_DATA_DIR unless absolute_path?(project_root)
-      return DEFAULT_DATA_DIR unless cwd_within?(project_root)
+      if project_root.nil? || project_root.empty?
+        raise ArgumentError,
+              "project root must be configured via TDD_GUARD_PROJECT_ROOT environment variable"
+      end
 
-      File.join(project_root, DEFAULT_DATA_DIR)
-    end
+      resolved = canonical_path(File.expand_path(project_root))
+      unless cwd_within?(resolved)
+        raise ArgumentError,
+              "current directory must be within project root #{resolved.inspect}"
+      end
 
-    def absolute_path?(path)
-      File.absolute_path?(path)
+      File.join(resolved, DEFAULT_DATA_DIR)
     end
 
     def cwd_within?(root)
-      expanded = File.expand_path(root)
-      cwd = Dir.pwd
-      cwd == expanded || cwd.start_with?("#{expanded}/")
+      cwd = canonical_path(Dir.pwd)
+      cwd == root || cwd.start_with?("#{root}/")
+    end
+
+    # Resolve symlinks when the path exists so that platforms with
+    # symlinked tempdirs (macOS /var -> /private/var) compare consistently.
+    def canonical_path(path)
+      File.realpath(path)
+    rescue Errno::ENOENT
+      path
     end
 
     # Injects a synthetic failed test entry derived from an exception raised

--- a/reporters/minitest/lib/tdd_guard_minitest/reporter.rb
+++ b/reporters/minitest/lib/tdd_guard_minitest/reporter.rb
@@ -184,7 +184,13 @@ module TddGuardMinitest
               "project root must be configured via TDD_GUARD_PROJECT_ROOT environment variable"
       end
 
-      resolved = canonical_path(File.expand_path(project_root))
+      expanded = File.expand_path(project_root)
+      unless File.directory?(expanded)
+        raise ArgumentError,
+              "project root does not exist: #{expanded.inspect}"
+      end
+
+      resolved = canonical_path(expanded)
       unless cwd_within?(resolved)
         raise ArgumentError,
               "current directory must be within project root #{resolved.inspect}"

--- a/reporters/minitest/spec/reporter_spec.rb
+++ b/reporters/minitest/spec/reporter_spec.rb
@@ -475,67 +475,86 @@ RSpec.describe TddGuardMinitest::Reporter do
   end
 
   describe "storage directory determination" do
-    it "uses default relative path when no env var set" do
+    it "raises when no env var is set" do
       Dir.mktmpdir do |tmpdir|
         real_tmpdir = File.realpath(tmpdir)
         Dir.chdir(real_tmpdir) do
           ClimateControl.modify("TDD_GUARD_PROJECT_ROOT" => nil) do
-            reporter = described_class.new(StringIO.new)
-            reporter.report
-
-            json_path = File.join(default_data_dir, "test.json")
-            expect(File.exist?(json_path)).to be true
+            expect { described_class.new(StringIO.new) }
+              .to raise_error(ArgumentError, /must be configured via TDD_GUARD_PROJECT_ROOT/)
           end
         end
       end
     end
 
-    it "rejects relative path in env var" do
+    it "raises when env var is empty" do
       Dir.mktmpdir do |tmpdir|
         real_tmpdir = File.realpath(tmpdir)
         Dir.chdir(real_tmpdir) do
-          ClimateControl.modify("TDD_GUARD_PROJECT_ROOT" => "../some/path") do
-            reporter = described_class.new(StringIO.new)
-            reporter.report
-
-            json_path = File.join(default_data_dir, "test.json")
-            expect(File.exist?(json_path)).to be true
-            expect(File.exist?(File.join("../some/path", default_data_dir, "test.json"))).to be false
+          ClimateControl.modify("TDD_GUARD_PROJECT_ROOT" => "") do
+            expect { described_class.new(StringIO.new) }
+              .to raise_error(ArgumentError, /must be configured via TDD_GUARD_PROJECT_ROOT/)
           end
         end
       end
     end
 
-    it "rejects project root when cwd is outside" do
+    it "accepts a relative path" do
+      Dir.mktmpdir do |tmpdir|
+        real_tmpdir = File.realpath(tmpdir)
+        Dir.chdir(real_tmpdir) do
+          ClimateControl.modify("TDD_GUARD_PROJECT_ROOT" => ".") do
+            reporter = described_class.new(StringIO.new)
+            reporter.report
+
+            json_path = File.join(real_tmpdir, default_data_dir, "test.json")
+            expect(File.exist?(json_path)).to be true
+          end
+        end
+      end
+    end
+
+    it "accepts a path containing .." do
+      Dir.mktmpdir do |tmpdir|
+        real_tmpdir = File.realpath(tmpdir)
+        sub_dir = File.join(real_tmpdir, "sub")
+        FileUtils.mkdir_p(sub_dir)
+        Dir.chdir(sub_dir) do
+          ClimateControl.modify("TDD_GUARD_PROJECT_ROOT" => "../") do
+            reporter = described_class.new(StringIO.new)
+            reporter.report
+
+            json_path = File.join(real_tmpdir, default_data_dir, "test.json")
+            expect(File.exist?(json_path)).to be true
+          end
+        end
+      end
+    end
+
+    it "raises when cwd is outside the project root" do
       Dir.mktmpdir do |tmpdir|
         real_tmpdir = File.realpath(tmpdir)
         Dir.chdir(real_tmpdir) do
           ClimateControl.modify("TDD_GUARD_PROJECT_ROOT" => "/other/project") do
-            reporter = described_class.new(StringIO.new)
-            reporter.report
-
-            json_path = File.join(default_data_dir, "test.json")
-            expect(File.exist?(json_path)).to be true
+            expect { described_class.new(StringIO.new) }
+              .to raise_error(ArgumentError, /current directory must be within project root/)
           end
         end
       end
     end
 
-    it "rejects project root that is a prefix of cwd but not an ancestor" do
+    it "raises when project root is a prefix of cwd but not an ancestor" do
       Dir.mktmpdir do |tmpdir|
         real_tmpdir = File.realpath(tmpdir)
         project_dir = File.join(real_tmpdir, "foo")
         similar_dir = File.join(real_tmpdir, "foobar")
+        FileUtils.mkdir_p(project_dir)
         FileUtils.mkdir_p(similar_dir)
 
         Dir.chdir(similar_dir) do
           ClimateControl.modify("TDD_GUARD_PROJECT_ROOT" => project_dir) do
-            reporter = described_class.new(StringIO.new)
-            reporter.report
-
-            json_path = File.join(default_data_dir, "test.json")
-            expect(File.exist?(json_path)).to be true
-            expect(File.exist?(File.join(project_dir, default_data_dir, "test.json"))).to be false
+            expect { described_class.new(StringIO.new) }
+              .to raise_error(ArgumentError, /current directory must be within project root/)
           end
         end
       end

--- a/reporters/minitest/spec/reporter_spec.rb
+++ b/reporters/minitest/spec/reporter_spec.rb
@@ -534,10 +534,52 @@ RSpec.describe TddGuardMinitest::Reporter do
     it "raises when cwd is outside the project root" do
       Dir.mktmpdir do |tmpdir|
         real_tmpdir = File.realpath(tmpdir)
+        Dir.mktmpdir do |outside_dir|
+          real_outside = File.realpath(outside_dir)
+          Dir.chdir(real_tmpdir) do
+            ClimateControl.modify("TDD_GUARD_PROJECT_ROOT" => real_outside) do
+              expect { described_class.new(StringIO.new) }
+                .to raise_error(ArgumentError, /current directory must be within project root/)
+            end
+          end
+        end
+      end
+    end
+
+    it "raises with a path-identifying error when project root does not exist" do
+      Dir.mktmpdir do |tmpdir|
+        real_tmpdir = File.realpath(tmpdir)
         Dir.chdir(real_tmpdir) do
-          ClimateControl.modify("TDD_GUARD_PROJECT_ROOT" => "/other/project") do
+          missing = File.join(real_tmpdir, "does", "not", "exist")
+          ClimateControl.modify("TDD_GUARD_PROJECT_ROOT" => missing) do
             expect { described_class.new(StringIO.new) }
-              .to raise_error(ArgumentError, /current directory must be within project root/)
+              .to raise_error(ArgumentError) do |err|
+                expect(err.message).to include("project root does not exist")
+                expect(err.message).to include(missing)
+              end
+          end
+        end
+      end
+    end
+
+    it "resolves storage dir correctly when project root and cwd differ via symlink" do
+      Dir.mktmpdir do |tmpdir|
+        real_outer = File.realpath(tmpdir)
+        real_root = File.join(real_outer, "real_root")
+        FileUtils.mkdir_p(real_root)
+        symlink_root = File.join(real_outer, "sym_root")
+        File.symlink(real_root, symlink_root)
+
+        # cwd reaches the project via the symlink while the env var points
+        # at the canonical real path. canonical_path on both sides should
+        # converge to real_root so cwd_within? still recognises the match.
+        Dir.chdir(symlink_root) do
+          ClimateControl.modify("TDD_GUARD_PROJECT_ROOT" => real_root) do
+            reporter = described_class.new(StringIO.new)
+            reporter.report
+
+            json_path = File.join(real_root, default_data_dir, "test.json")
+            expect(File.exist?(json_path)).to be true
           end
         end
       end

--- a/reporters/rspec/README.md
+++ b/reporters/rspec/README.md
@@ -50,9 +50,9 @@ export TDD_GUARD_PROJECT_ROOT="/absolute/path/to/project/root"
 
 ### Configuration Rules
 
-- Path must be absolute
-- Current directory must be within the configured project root
-- Falls back to current directory if configuration is invalid
+- Set `TDD_GUARD_PROJECT_ROOT` to the project root. Absolute and relative paths are both accepted; relative paths resolve against the working directory at runtime.
+- Tests must be run from a directory at or below the project root.
+- The reporter raises at startup when the variable is not set. It no longer silently falls back to the current directory.
 
 ## Development
 

--- a/reporters/rspec/lib/tdd_guard_rspec/formatter.rb
+++ b/reporters/rspec/lib/tdd_guard_rspec/formatter.rb
@@ -178,21 +178,31 @@ module TddGuardRspec
 
     def determine_storage_dir
       project_root = ENV["TDD_GUARD_PROJECT_ROOT"]
-      return DEFAULT_DATA_DIR unless project_root && !project_root.empty?
-      return DEFAULT_DATA_DIR unless absolute_path?(project_root)
-      return DEFAULT_DATA_DIR unless cwd_within?(project_root)
+      if project_root.nil? || project_root.empty?
+        raise ArgumentError,
+              "project root must be configured via TDD_GUARD_PROJECT_ROOT environment variable"
+      end
 
-      File.join(project_root, DEFAULT_DATA_DIR)
-    end
+      resolved = canonical_path(File.expand_path(project_root))
+      unless cwd_within?(resolved)
+        raise ArgumentError,
+              "current directory must be within project root #{resolved.inspect}"
+      end
 
-    def absolute_path?(path)
-      File.absolute_path?(path)
+      File.join(resolved, DEFAULT_DATA_DIR)
     end
 
     def cwd_within?(root)
-      expanded = File.expand_path(root)
-      cwd = Dir.pwd
-      cwd == expanded || cwd.start_with?("#{expanded}/")
+      cwd = canonical_path(Dir.pwd)
+      cwd == root || cwd.start_with?("#{root}/")
+    end
+
+    # Resolve symlinks when the path exists so that platforms with
+    # symlinked tempdirs (macOS /var -> /private/var) compare consistently.
+    def canonical_path(path)
+      File.realpath(path)
+    rescue Errno::ENOENT
+      path
     end
   end
 end

--- a/reporters/rspec/lib/tdd_guard_rspec/formatter.rb
+++ b/reporters/rspec/lib/tdd_guard_rspec/formatter.rb
@@ -183,7 +183,13 @@ module TddGuardRspec
               "project root must be configured via TDD_GUARD_PROJECT_ROOT environment variable"
       end
 
-      resolved = canonical_path(File.expand_path(project_root))
+      expanded = File.expand_path(project_root)
+      unless File.directory?(expanded)
+        raise ArgumentError,
+              "project root does not exist: #{expanded.inspect}"
+      end
+
+      resolved = canonical_path(expanded)
       unless cwd_within?(resolved)
         raise ArgumentError,
               "current directory must be within project root #{resolved.inspect}"

--- a/reporters/rspec/spec/formatter_spec.rb
+++ b/reporters/rspec/spec/formatter_spec.rb
@@ -476,10 +476,52 @@ RSpec.describe TddGuardRspec::Formatter do
     it "raises when cwd is outside the project root" do
       Dir.mktmpdir do |tmpdir|
         real_tmpdir = File.realpath(tmpdir)
+        Dir.mktmpdir do |outside_dir|
+          real_outside = File.realpath(outside_dir)
+          Dir.chdir(real_tmpdir) do
+            ClimateControl.modify("TDD_GUARD_PROJECT_ROOT" => real_outside) do
+              expect { described_class.new(StringIO.new) }
+                .to raise_error(ArgumentError, /current directory must be within project root/)
+            end
+          end
+        end
+      end
+    end
+
+    it "raises with a path-identifying error when project root does not exist" do
+      Dir.mktmpdir do |tmpdir|
+        real_tmpdir = File.realpath(tmpdir)
         Dir.chdir(real_tmpdir) do
-          ClimateControl.modify("TDD_GUARD_PROJECT_ROOT" => "/other/project") do
+          missing = File.join(real_tmpdir, "does", "not", "exist")
+          ClimateControl.modify("TDD_GUARD_PROJECT_ROOT" => missing) do
             expect { described_class.new(StringIO.new) }
-              .to raise_error(ArgumentError, /current directory must be within project root/)
+              .to raise_error(ArgumentError) do |err|
+                expect(err.message).to include("project root does not exist")
+                expect(err.message).to include(missing)
+              end
+          end
+        end
+      end
+    end
+
+    it "resolves storage dir correctly when project root and cwd differ via symlink" do
+      Dir.mktmpdir do |tmpdir|
+        real_outer = File.realpath(tmpdir)
+        real_root = File.join(real_outer, "real_root")
+        FileUtils.mkdir_p(real_root)
+        symlink_root = File.join(real_outer, "sym_root")
+        File.symlink(real_root, symlink_root)
+
+        # cwd reaches the project via the symlink while the env var points
+        # at the canonical real path. canonical_path on both sides should
+        # converge to real_root so cwd_within? still recognises the match.
+        Dir.chdir(symlink_root) do
+          ClimateControl.modify("TDD_GUARD_PROJECT_ROOT" => real_root) do
+            formatter = described_class.new(StringIO.new)
+            formatter.close(double("notification"))
+
+            json_path = File.join(real_root, default_data_dir, "test.json")
+            expect(File.exist?(json_path)).to be true
           end
         end
       end

--- a/reporters/rspec/spec/formatter_spec.rb
+++ b/reporters/rspec/spec/formatter_spec.rb
@@ -417,69 +417,86 @@ RSpec.describe TddGuardRspec::Formatter do
   end
 
   describe "storage directory determination" do
-    it "uses default relative path when no env var set" do
+    it "raises when no env var is set" do
       Dir.mktmpdir do |tmpdir|
         real_tmpdir = File.realpath(tmpdir)
         Dir.chdir(real_tmpdir) do
           ClimateControl.modify("TDD_GUARD_PROJECT_ROOT" => nil) do
-            formatter = described_class.new(StringIO.new)
-            formatter.close(double("notification"))
-
-            json_path = File.join(default_data_dir, "test.json")
-            expect(File.exist?(json_path)).to be true
+            expect { described_class.new(StringIO.new) }
+              .to raise_error(ArgumentError, /must be configured via TDD_GUARD_PROJECT_ROOT/)
           end
         end
       end
     end
 
-    it "rejects relative path in env var" do
+    it "raises when env var is empty" do
       Dir.mktmpdir do |tmpdir|
         real_tmpdir = File.realpath(tmpdir)
         Dir.chdir(real_tmpdir) do
-          ClimateControl.modify("TDD_GUARD_PROJECT_ROOT" => "../some/path") do
-            formatter = described_class.new(StringIO.new)
-            formatter.close(double("notification"))
-
-            json_path = File.join(default_data_dir, "test.json")
-            expect(File.exist?(json_path)).to be true
-            # Should NOT have written to the project root path
-            expect(File.exist?(File.join("../some/path", default_data_dir, "test.json"))).to be false
+          ClimateControl.modify("TDD_GUARD_PROJECT_ROOT" => "") do
+            expect { described_class.new(StringIO.new) }
+              .to raise_error(ArgumentError, /must be configured via TDD_GUARD_PROJECT_ROOT/)
           end
         end
       end
     end
 
-    it "rejects project root when cwd is outside" do
+    it "accepts a relative path" do
+      Dir.mktmpdir do |tmpdir|
+        real_tmpdir = File.realpath(tmpdir)
+        Dir.chdir(real_tmpdir) do
+          ClimateControl.modify("TDD_GUARD_PROJECT_ROOT" => ".") do
+            formatter = described_class.new(StringIO.new)
+            formatter.close(double("notification"))
+
+            json_path = File.join(real_tmpdir, default_data_dir, "test.json")
+            expect(File.exist?(json_path)).to be true
+          end
+        end
+      end
+    end
+
+    it "accepts a path containing .." do
+      Dir.mktmpdir do |tmpdir|
+        real_tmpdir = File.realpath(tmpdir)
+        sub_dir = File.join(real_tmpdir, "sub")
+        FileUtils.mkdir_p(sub_dir)
+        Dir.chdir(sub_dir) do
+          ClimateControl.modify("TDD_GUARD_PROJECT_ROOT" => "../") do
+            formatter = described_class.new(StringIO.new)
+            formatter.close(double("notification"))
+
+            json_path = File.join(real_tmpdir, default_data_dir, "test.json")
+            expect(File.exist?(json_path)).to be true
+          end
+        end
+      end
+    end
+
+    it "raises when cwd is outside the project root" do
       Dir.mktmpdir do |tmpdir|
         real_tmpdir = File.realpath(tmpdir)
         Dir.chdir(real_tmpdir) do
           ClimateControl.modify("TDD_GUARD_PROJECT_ROOT" => "/other/project") do
-            formatter = described_class.new(StringIO.new)
-            formatter.close(double("notification"))
-
-            json_path = File.join(default_data_dir, "test.json")
-            expect(File.exist?(json_path)).to be true
+            expect { described_class.new(StringIO.new) }
+              .to raise_error(ArgumentError, /current directory must be within project root/)
           end
         end
       end
     end
 
-    it "rejects project root that is a prefix of cwd but not an ancestor" do
+    it "raises when project root is a prefix of cwd but not an ancestor" do
       Dir.mktmpdir do |tmpdir|
         real_tmpdir = File.realpath(tmpdir)
         project_dir = File.join(real_tmpdir, "foo")
         similar_dir = File.join(real_tmpdir, "foobar")
+        FileUtils.mkdir_p(project_dir)
         FileUtils.mkdir_p(similar_dir)
 
         Dir.chdir(similar_dir) do
           ClimateControl.modify("TDD_GUARD_PROJECT_ROOT" => project_dir) do
-            formatter = described_class.new(StringIO.new)
-            formatter.close(double("notification"))
-
-            json_path = File.join(default_data_dir, "test.json")
-            expect(File.exist?(json_path)).to be true
-            # Should NOT have written under the project root
-            expect(File.exist?(File.join(project_dir, default_data_dir, "test.json"))).to be false
+            expect { described_class.new(StringIO.new) }
+              .to raise_error(ArgumentError, /current directory must be within project root/)
           end
         end
       end


### PR DESCRIPTION
## Summary

Apply ADR-009 (relax path validation) and ADR-010 (drop silent cwd fallback) to the Ruby reporters, following the same pattern as PR #151 (PHPUnit), #153 (Go), and #154 (Rust).

## Details

- Accept relative paths and paths containing `..`, resolved via `File.expand_path` against the working directory.
- Raise `ArgumentError` when `TDD_GUARD_PROJECT_ROOT` is not configured. Per ADR-010 this is an intentional breaking change so misconfiguration surfaces upfront instead of writing results to the wrong location.
- Preserve the cwd-within-root sanity check on the resolved path, using `File.realpath` to canonicalize symlinks so platforms with symlinked tempdirs (macOS `/var` -> `/private/var`) compare consistently.
- The Minitest reporter's `.handle_load_error` and `.append_unhandled_errors` class methods rescue the configuration `ArgumentError` so the autorun at_exit hooks do not double-raise when the env var is missing.

## Notes

- Rationale recorded in [ADR-009](docs/adr/009-relax-reporter-project-root-validation.md) and [ADR-010](docs/adr/010-standardize-project-root-env-var.md).
- Closes #173, #174.