### PR TITLE
fix(minitest): scrub non-UTF-8 bytes from failure messages

### DIFF
--- a/reporters/minitest/lib/tdd_guard_minitest/reporter.rb
+++ b/reporters/minitest/lib/tdd_guard_minitest/reporter.rb
@@ -130,7 +130,7 @@ module TddGuardMinitest
 
     def build_unhandled_error(exception)
       name = exception.class.name || "(anonymous error class)"
-      error = { "name" => name, "message" => exception.message }
+      error = { "name" => name, "message" => scrub_utf8(exception.message) }
       stack = extract_relevant_stack(exception.backtrace)
       error["stack"] = stack if stack
       error
@@ -139,14 +139,29 @@ module TddGuardMinitest
     def build_error(failure)
       if failure.is_a?(Minitest::UnexpectedError)
         exception = failure.error
-        error = { "message" => exception.message }
+        error = { "message" => scrub_utf8(exception.message) }
         stack = extract_relevant_stack(exception.backtrace)
       else
-        error = { "message" => failure.message }
+        error = { "message" => scrub_utf8(failure.message) }
         stack = extract_relevant_stack(failure.backtrace)
       end
       error["stack"] = stack if stack
       error
+    end
+
+    # Replace bytes that cannot be represented as UTF-8 so that
+    # JSON.pretty_generate does not raise on binary or alternately
+    # encoded strings (e.g. Shift_JIS, ASCII-8BIT). Valid UTF-8
+    # strings, including Japanese, pass through unchanged.
+    def scrub_utf8(str)
+      return str unless str.is_a?(String)
+      return str if str.encoding == Encoding::UTF_8 && str.valid_encoding?
+
+      if str.encoding == Encoding::UTF_8
+        str.scrub
+      else
+        str.encode("UTF-8", invalid: :replace, undef: :replace)
+      end
     end
 
     def extract_relevant_stack(backtrace)
@@ -195,8 +210,9 @@ module TddGuardMinitest
     def add_load_error(exception)
       frame = first_user_frame(exception.backtrace)
       file_path = frame ? frame.split(":", 2).first.to_s.sub(%r{^\./}, "") : "unknown"
-      name = "#{exception.class}: #{exception.message.lines.first.to_s.strip}"
-      message = build_load_error_message(exception, frame)
+      msg = scrub_utf8(exception.message)
+      name = "#{exception.class}: #{msg.lines.first.to_s.strip}"
+      message = build_load_error_message(exception, frame, msg)
 
       @test_results << {
         "name" => name,
@@ -214,8 +230,9 @@ module TddGuardMinitest
       end
     end
 
-    def build_load_error_message(exception, frame)
-      header = "#{exception.class}: #{exception.message}"
+    def build_load_error_message(exception, frame, message = nil)
+      msg = message || scrub_utf8(exception.message)
+      header = "#{exception.class}: #{msg}"
       return header unless frame
 
       "#{header}\n    #{frame.sub(%r{^\./}, '')}"

--- a/reporters/minitest/spec/reporter_spec.rb
+++ b/reporters/minitest/spec/reporter_spec.rb
@@ -416,6 +416,87 @@ RSpec.describe TddGuardMinitest::Reporter do
     end
   end
 
+  describe "non-utf-8 message handling" do
+    it "scrubs binary (ASCII-8BIT) bytes from a failure message" do
+      Dir.mktmpdir do |tmpdir|
+        create_reporter_in(tmpdir) do |reporter, storage_dir|
+          failure = build_assertion_failure(message: "binary: \xff\xfe".b)
+          reporter.record(
+            build_result(name: "test_with_binary", klass: "BinaryTest",
+                         source_location: ["./test/binary_test.rb", 5],
+                         failures: [failure])
+          )
+
+          data = run_and_read_json(reporter, storage_dir)
+          tests = all_tests(data)
+          expect(tests.length).to eq(1)
+          expect(tests[0]["state"]).to eq("failed")
+          expect(tests[0]["errors"][0]["message"]).to start_with("binary: ")
+        end
+      end
+    end
+
+    it "preserves valid UTF-8 (including Japanese) unchanged" do
+      Dir.mktmpdir do |tmpdir|
+        create_reporter_in(tmpdir) do |reporter, storage_dir|
+          failure = build_assertion_failure(message: "失敗しました")
+          reporter.record(
+            build_result(name: "test_japanese", klass: "JaTest",
+                         source_location: ["./test/ja_test.rb", 5],
+                         failures: [failure])
+          )
+
+          data = run_and_read_json(reporter, storage_dir)
+          tests = all_tests(data)
+          expect(tests[0]["errors"][0]["message"]).to eq("失敗しました")
+        end
+      end
+    end
+
+    it "transcodes Shift_JIS messages to UTF-8" do
+      Dir.mktmpdir do |tmpdir|
+        create_reporter_in(tmpdir) do |reporter, storage_dir|
+          failure = build_assertion_failure(message: "失敗".encode("Shift_JIS"))
+          reporter.record(
+            build_result(name: "test_sjis", klass: "SjisTest",
+                         source_location: ["./test/sjis_test.rb", 5],
+                         failures: [failure])
+          )
+
+          data = run_and_read_json(reporter, storage_dir)
+          tests = all_tests(data)
+          expect(tests[0]["errors"][0]["message"]).to eq("失敗")
+        end
+      end
+    end
+
+    it "preserves other tests in the same run when one has a non-utf-8 message" do
+      Dir.mktmpdir do |tmpdir|
+        create_reporter_in(tmpdir) do |reporter, storage_dir|
+          reporter.record(
+            build_result(name: "test_pass_one", klass: "MixTest",
+                         source_location: ["./test/mix_test.rb", 1])
+          )
+          reporter.record(
+            build_result(name: "test_binary_fail", klass: "MixTest",
+                         source_location: ["./test/mix_test.rb", 5],
+                         failures: [build_assertion_failure(message: "\xff\xfe".b)])
+          )
+          reporter.record(
+            build_result(name: "test_pass_two", klass: "MixTest",
+                         source_location: ["./test/mix_test.rb", 9])
+          )
+
+          data = run_and_read_json(reporter, storage_dir)
+          tests = all_tests(data)
+          expect(tests.length).to eq(3)
+          states = tests.map { |t| t["state"] }
+          expect(states).to contain_exactly("passed", "passed", "failed")
+        end
+      end
+    end
+  end
+
   describe "name extraction" do
     it "uses result.name as name" do
       Dir.mktmpdir do |tmpdir|


### PR DESCRIPTION
## Summary

A failure message containing bytes that are not valid UTF-8 (for example a binary blob or a Shift_JIS encoded string) made `JSON.pretty_generate` raise mid-write. The reporter could not produce a valid `test.json`, the autorun load-error fallback then wrote a synthetic entry describing the JSON error itself, and every other test result from the same run was lost.

## Reproduction

```ruby
class BinaryTest < ActiveSupport::TestCase
  test("pass1") { assert true }
  test("binary") { flunk "binary: \xff\xfe".b }
  test("pass2") { assert true }
end
```

Before this fix `test.json` contained a single synthetic `JSON::GeneratorError` entry with `moduleId: "unknown"` and the two passing tests were missing.

## Fix

Add a small `scrub_utf8` helper used at every site where an exception or failure message enters the JSON tree. Valid UTF-8 strings (including Japanese) pass through unchanged, already-tagged UTF-8 strings with invalid bytes are scrubbed, and strings tagged with another encoding are transcoded with `invalid: :replace, undef: :replace`.

## Tests

Four new specs under `non-utf-8 message handling`:
- ASCII-8BIT bytes are scrubbed.
- Valid UTF-8 Japanese is preserved unchanged.
- Shift_JIS messages are transcoded to UTF-8.
- Other tests in the same run are preserved when one has a non-UTF-8 message.

Closes #175.