### PR TITLE
fix(minitest): overwrite stale test.json on load error

### DIFF
--- a/reporters/minitest/lib/tdd_guard_minitest/reporter.rb
+++ b/reporters/minitest/lib/tdd_guard_minitest/reporter.rb
@@ -6,9 +6,11 @@ require "minitest"
 
 module TddGuardMinitest
   @unhandled_errors = []
+  @reported = false
 
   class << self
     attr_reader :unhandled_errors
+    attr_accessor :reported
   end
 
   # Minitest reporter that captures test results for TDD Guard validation.
@@ -34,8 +36,11 @@ module TddGuardMinitest
     # point's at_exit hook when $! is set.
     #
     # Injects a synthetic entry into @test_results and writes the JSON
-    # through the normal report path. Skips if test.json already exists
-    # to avoid clobbering real results.
+    # through the normal report path. Skips when this process has already
+    # written test.json via the normal Minitest flow, so it never clobbers
+    # real results from the same run. A stale test.json left behind by a
+    # previous process is overwritten so the file always reflects the most
+    # recent run's state.
     def self.handle_load_error(exception)
       new(StringIO.new).handle_load_error(exception)
     end
@@ -57,7 +62,7 @@ module TddGuardMinitest
     end
 
     def handle_load_error(exception)
-      return if File.exist?(File.join(@storage_dir, "test.json"))
+      return if TddGuardMinitest.reported
 
       add_load_error(exception)
       report
@@ -109,6 +114,7 @@ module TddGuardMinitest
 
       FileUtils.mkdir_p(@storage_dir)
       File.write(File.join(@storage_dir, "test.json"), JSON.pretty_generate(result))
+      TddGuardMinitest.reported = true
     end
 
     def passed?

--- a/reporters/minitest/spec/reporter_spec.rb
+++ b/reporters/minitest/spec/reporter_spec.rb
@@ -775,6 +775,9 @@ RSpec.describe TddGuardMinitest::Reporter do
   end
 
   describe ".handle_load_error" do
+    before { TddGuardMinitest.reported = false }
+    after  { TddGuardMinitest.reported = false }
+
     # Helper: run handle_load_error in an isolated tmpdir and return parsed JSON
     def run_handle_load_error_in(tmpdir, exception)
       real_tmpdir = File.realpath(tmpdir)
@@ -902,14 +905,14 @@ RSpec.describe TddGuardMinitest::Reporter do
       end
     end
 
-    it "does not overwrite an existing test.json" do
+    it "overwrites a stale test.json left behind by a previous process" do
       Dir.mktmpdir do |tmpdir|
         real_tmpdir = File.realpath(tmpdir)
         Dir.chdir(real_tmpdir) do
           ClimateControl.modify("TDD_GUARD_PROJECT_ROOT" => real_tmpdir) do
             json_path = File.join(real_tmpdir, default_data_dir, "test.json")
             FileUtils.mkdir_p(File.dirname(json_path))
-            File.write(json_path, '{"existing":"results"}')
+            File.write(json_path, '{"testModules":[],"reason":"passed"}')
 
             exc = build_load_error(
               message: "cannot load such file -- my_class",
@@ -917,7 +920,37 @@ RSpec.describe TddGuardMinitest::Reporter do
             )
             described_class.handle_load_error(exc)
 
-            expect(File.read(json_path)).to eq('{"existing":"results"}')
+            data = JSON.parse(File.read(json_path))
+            expect(data["reason"]).to eq("failed")
+            expect(data["testModules"][0]["moduleId"]).to eq("test/my_class_test.rb")
+          end
+        end
+      end
+    end
+
+    it "does not overwrite test.json after report has run in this process" do
+      Dir.mktmpdir do |tmpdir|
+        real_tmpdir = File.realpath(tmpdir)
+        Dir.chdir(real_tmpdir) do
+          ClimateControl.modify("TDD_GUARD_PROJECT_ROOT" => real_tmpdir) do
+            reporter = described_class.new(StringIO.new)
+            reporter.record(
+              build_result(name: "test_passes", klass: "MyTest",
+                           source_location: ["./test/my_test.rb", 5])
+            )
+            reporter.report  # sets the in-process flag
+
+            exc = build_load_error(
+              message: "cannot load such file -- my_class",
+              backtrace: ["./test/my_class_test.rb:3:in `require'"]
+            )
+            described_class.handle_load_error(exc)
+
+            json_path = File.join(real_tmpdir, default_data_dir, "test.json")
+            data = JSON.parse(File.read(json_path))
+            tests = data["testModules"].flat_map { |m| m["tests"] }
+            expect(tests.length).to eq(1)
+            expect(tests[0]["name"]).to eq("test_passes")
           end
         end
       end


### PR DESCRIPTION
## Summary

`handle_load_error` skipped writing whenever `test.json` already existed. The intent was to avoid clobbering this run's results, but the file-existence check could not distinguish a file from a prior process from one this process had just written. A pass in run 1 followed by a require error in run 2 left run 1's green state visible to TDD Guard.

## Reproduction (real Rails app)

Run 1: tests pass.

```
test.json: { reason: "passed", tests: [{ state: "passed", name: "test_initially_passes" }] }
```

Edit a test file to add `require "missing_file"`, then run again.

Before this fix, after the load error in run 2:

```
test.json: { reason: "passed", tests: [{ state: "passed", name: "test_initially_passes" }] }
                                  ^^^ unchanged from run 1, hides the real failure
```

After this fix:

```
test.json: { reason: "failed", tests: [{ state: "failed", name: "LoadError: cannot load such file -- ..." }] }
```

## Fix

Replace the file-existence guard with a process-local flag set at the end of `report`. Within-process protection is preserved (the normal Minitest flow still wins when both fire); stale files from previous processes are overwritten so `test.json` always reflects the current run's state.

## Tests

The previous "does not overwrite an existing test.json" spec asserted the old, buggy behavior; replaced with two specs:

- "overwrites a stale test.json left behind by a previous process"
- "does not overwrite test.json after report has run in this process"

Closes #179.