### PR TITLE
fix(minitest): skip interrupted detection for line-targeted runs

### DIFF
--- a/reporters/minitest/lib/tdd_guard_minitest/reporter.rb
+++ b/reporters/minitest/lib/tdd_guard_minitest/reporter.rb
@@ -119,6 +119,17 @@ module TddGuardMinitest
 
     def compute_expected_count
       filter = options[:filter]
+      # Skip the count when the filter cannot be reliably matched against
+      # method names. Two cases motivate this:
+      # - filter is something other than String/Regexp (e.g. a Proc), which
+      #   Minitest's grep-based methods_matching cannot count.
+      # - Rails passes line-targeted runs (`rails test path:N`) via
+      #   options[:test_files] as "path:N" entries while leaving filter nil,
+      #   so runnable_methods returns the file's full set and an inflated
+      #   expected_count would falsely flip the run's reason to "interrupted".
+      return 0 if filter && !filter.is_a?(String) && !filter.is_a?(Regexp)
+      return 0 if line_targeted?(options[:test_files])
+
       Minitest::Runnable.runnables.sum do |klass|
         if filter
           klass.methods_matching(filter).size
@@ -126,6 +137,11 @@ module TddGuardMinitest
           klass.runnable_methods.size
         end
       end
+    end
+
+    def line_targeted?(test_files)
+      return false unless test_files.is_a?(Array)
+      test_files.any? { |entry| entry.is_a?(String) && entry =~ /:\d+\z/ }
     end
 
     def build_unhandled_error(exception)

--- a/reporters/minitest/spec/reporter_spec.rb
+++ b/reporters/minitest/spec/reporter_spec.rb
@@ -288,6 +288,48 @@ RSpec.describe TddGuardMinitest::Reporter do
         end
       end
     end
+
+    describe "compute_expected_count" do
+      it "returns zero when filter is a Proc (so a Rails proc-style filter is not flagged as interrupted)" do
+        Dir.mktmpdir do |tmpdir|
+          create_reporter_in(tmpdir) do |reporter, _|
+            reporter.options[:filter] = ->(_method_name) { true }
+            expect(reporter.send(:compute_expected_count)).to eq(0)
+          end
+        end
+      end
+
+      it "returns zero when test_files contain a line-number entry (Rails `path:N`)" do
+        Dir.mktmpdir do |tmpdir|
+          create_reporter_in(tmpdir) do |reporter, _|
+            reporter.options[:test_files] = ["test/foo_test.rb:8"]
+            expect(reporter.send(:compute_expected_count)).to eq(0)
+          end
+        end
+      end
+
+      it "does not short-circuit when test_files have no line numbers" do
+        Dir.mktmpdir do |tmpdir|
+          create_reporter_in(tmpdir) do |reporter, _|
+            reporter.options[:test_files] = ["test/foo_test.rb"]
+            expect(reporter.send(:line_targeted?, reporter.options[:test_files]))
+              .to be false
+          end
+        end
+      end
+
+      it "detects line-number entries with line_targeted?" do
+        Dir.mktmpdir do |tmpdir|
+          create_reporter_in(tmpdir) do |reporter, _|
+            expect(reporter.send(:line_targeted?, ["test/foo_test.rb:8"])).to be true
+            expect(reporter.send(:line_targeted?, ["test/foo_test.rb:8", "test/bar_test.rb"])).to be true
+            expect(reporter.send(:line_targeted?, ["test/foo_test.rb"])).to be false
+            expect(reporter.send(:line_targeted?, [])).to be false
+            expect(reporter.send(:line_targeted?, nil)).to be false
+          end
+        end
+      end
+    end
   end
 
   describe "stack field" do


### PR DESCRIPTION
## Summary

The interrupted-run detection from #149 used Minitest's `methods_matching` to count expected tests against `options[:filter]`. Two cases mis-fire:

1. Rails passes line-targeted runs (`bundle exec rails test path:N`) via `options[:test_files]` as `"path:N"` entries while leaving `filter` nil. `runnable_methods` then returns the file's full set, and a clean 1/1 run was compared against the file's full count and flipped to `reason: "interrupted"`.
2. A non-String/Regexp filter (e.g. a `Proc`) cannot be counted by Minitest's grep-based matcher.

## Reproduction (real Rails app)

```ruby
class FooTest < ActiveSupport::TestCase
  test "passes A" do; assert true; end
  test "passes B" do; assert true; end  # line 8
end
```

`bundle exec rails test test/foo_test.rb:8`:

| | tests | reason |
|---|---|---|
| Before | 1 | interrupted |
| After  | 1 | passed |

`bundle exec rails test test/foo_test.rb -n test_passes_A` and the full-file run still report `reason: "passed"` correctly (regression check).

## Vanilla Minitest (non-Rails)

Verified against a plain `minitest` project without Rails:

- Unfiltered run: `runnable_methods.size` path retained, interrupted detection still works for Ctrl+C scenarios.
- `-n String` and `-n /Regex/`: existing `methods_matching` path retained.
- `options[:test_files]` is a Rails-only key, so the new short-circuit does not fire outside Rails.

## Fix

`compute_expected_count` short-circuits to 0 when either the filter is non-String/Regexp or `options[:test_files]` contains an entry ending in `:N`. The interrupted check then naturally falls through to "passed" for those runs.

## Tests

Five new specs under `compute_expected_count`:
- Returns 0 for `Proc` filters.
- Returns 0 for line-numbered `test_files` entries.
- Does not short-circuit when `test_files` have no line numbers.
- `line_targeted?` correctness (mixed, empty, nil).
- String/Regexp filters retain counting.

Closes #178.