### PR TITLE
fix(rspec): do not report reason "passed" when no examples ran

### DIFF
--- a/reporters/rspec/lib/tdd_guard_rspec/formatter.rb
+++ b/reporters/rspec/lib/tdd_guard_rspec/formatter.rb
@@ -78,9 +78,17 @@ module TddGuardRspec
       end
 
       has_failures = @test_results.any? { |t| t["state"] == "failed" }
-      reason = if has_failures
+      has_errors = !@unhandled_errors.empty? || @errors_outside > 0
+      reason = if has_failures || has_errors
                  "failed"
                elsif @expected_count > 0 && @test_results.length < @expected_count
+                 "interrupted"
+               elsif @test_results.empty?
+                 # No examples actually ran (e.g. spec file aborted before
+                 # the start callback fired due to a SyntaxError, or an
+                 # empty `RSpec.describe` collected zero examples). Treat
+                 # this as "interrupted" rather than claiming "passed",
+                 # since nothing exercised the suite.
                  "interrupted"
                else
                  "passed"

--- a/reporters/rspec/spec/formatter_spec.rb
+++ b/reporters/rspec/spec/formatter_spec.rb
@@ -109,7 +109,9 @@ RSpec.describe TddGuardRspec::Formatter do
         create_formatter_in(tmpdir) do |formatter, storage_dir|
           data = run_and_read_json(formatter, storage_dir)
           expect(data["testModules"]).to eq([])
-          expect(data["reason"]).to eq("passed")
+          # No examples actually ran, so the reporter no longer claims
+          # "passed" — see #177.
+          expect(data["reason"]).to eq("interrupted")
         end
       end
     end
@@ -238,13 +240,34 @@ RSpec.describe TddGuardRspec::Formatter do
       end
     end
 
-    it "reports passed when expected count is zero" do
+    it "reports interrupted when expected count is zero and nothing ran" do
+      # An empty `RSpec.describe` (or a `--tag` filter that matches no
+      # examples) collects zero examples. Before #177, this returned
+      # "passed", which silently lied to TDD Guard about a suite that
+      # never executed an assertion.
       Dir.mktmpdir do |tmpdir|
         create_formatter_in(tmpdir) do |formatter, storage_dir|
           formatter.start(build_start_notification(count: 0))
 
           data = run_and_read_json(formatter, storage_dir)
-          expect(data["reason"]).to eq("passed")
+          expect(data["reason"]).to eq("interrupted")
+        end
+      end
+    end
+
+    it "reports failed when an unhandled error is captured (no examples ran)" do
+      # Simulates a SyntaxError in a spec file: RSpec aborts during file
+      # loading, the start callback never fires, but the :message callback
+      # records the error via @unhandled_errors. Reason must reflect the
+      # failure even though @expected_count stays zero (see #177).
+      Dir.mktmpdir do |tmpdir|
+        create_formatter_in(tmpdir) do |formatter, storage_dir|
+          formatter.instance_variable_set(:@unhandled_errors, [
+            { "name" => "SyntaxError", "message" => "Unmatched (" }
+          ])
+
+          data = run_and_read_json(formatter, storage_dir)
+          expect(data["reason"]).to eq("failed")
         end
       end
     end


### PR DESCRIPTION
## Summary

Follow-up to #129. Two scenarios still produce `reason: "passed"` while no examples actually exercised the suite:

1. A spec file with a `SyntaxError`. RSpec aborts during loading, the start callback never fires (so `expected_count` stays 0), and the `:message` callback records the error via `@unhandled_errors`. The reason logic only checked failures and falls through to `"passed"`.
2. An empty `RSpec.describe` (or a filter that matches no examples). `expected_count` is 0 and `@test_results` is empty, so the same fall-through to `"passed"` hits.

The reason field is part of the reporter contract that the validator hook reads. Claiming `"passed"` when nothing ran lets a broken or empty suite slip through TDD Guard as if it had passed.

## Reproduction (vanilla RSpec, also confirmed in a Rails app)

| Scenario | Before | After |
|---|---|---|
| SyntaxError in a spec | `reason: "passed"`, `unhandledErrors: [SyntaxError]` | `reason: "failed"`, same `unhandledErrors` |
| Empty `RSpec.describe` | `reason: "passed"` | `reason: "interrupted"` |
| Real passing example  | `reason: "passed"` | `reason: "passed"` (no regression) |
| Real failing example  | `reason: "failed"` | `reason: "failed"` (no regression) |

## Fix

`#close` reason logic now treats `unhandled_errors` non-empty or `errors_outside > 0` as a failure signal, and treats an empty `@test_results` as `"interrupted"` rather than `"passed"`.

## Tests

- Updated "saves empty testModules when no tests ran" to expect `"interrupted"`.
- Renamed "reports passed when expected count is zero" to "reports interrupted when expected count is zero and nothing ran" with the new assertion.
- Added "reports failed when an unhandled error is captured (no examples ran)".

Closes #177.