### PR TITLE
fix(minitest): strip cwd from load-error moduleId

### DIFF
--- a/reporters/minitest/lib/tdd_guard_minitest/reporter.rb
+++ b/reporters/minitest/lib/tdd_guard_minitest/reporter.rb
@@ -201,8 +201,17 @@ module TddGuardMinitest
       source = result.source_location
       return "unknown" unless source
 
-      path = source.first
-      # Convert absolute path to relative path from cwd
+      relative_path(source.first)
+    end
+
+    # Strip a leading cwd prefix and any "./" so file paths in test.json
+    # are reported relative to the project root regardless of whether they
+    # arrived as absolute paths (from a backtrace) or already-relative
+    # paths (from result.source_location).
+    def relative_path(path)
+      return "unknown" if path.nil? || path.to_s.empty?
+
+      path = path.to_s
       cwd = "#{Dir.pwd}/"
       path = path.delete_prefix(cwd) if path.start_with?(cwd)
       path.sub(%r{^\./}, "")
@@ -231,7 +240,7 @@ module TddGuardMinitest
     # before Minitest could run.
     def add_load_error(exception)
       frame = first_user_frame(exception.backtrace)
-      file_path = frame ? frame.split(":", 2).first.to_s.sub(%r{^\./}, "") : "unknown"
+      file_path = frame ? relative_path(frame.split(":", 2).first) : "unknown"
       msg = scrub_utf8(exception.message)
       name = "#{exception.class}: #{msg.lines.first.to_s.strip}"
       message = build_load_error_message(exception, frame, msg)
@@ -257,7 +266,7 @@ module TddGuardMinitest
       header = "#{exception.class}: #{msg}"
       return header unless frame
 
-      "#{header}\n    #{frame.sub(%r{^\./}, '')}"
+      "#{header}\n    #{relative_path(frame)}"
     end
   end
 end

--- a/reporters/minitest/spec/reporter_spec.rb
+++ b/reporters/minitest/spec/reporter_spec.rb
@@ -869,6 +869,36 @@ RSpec.describe TddGuardMinitest::Reporter do
       end
     end
 
+    it "strips the cwd prefix from absolute backtrace paths so moduleId is relative" do
+      Dir.mktmpdir do |tmpdir|
+        real_tmpdir = File.realpath(tmpdir)
+        absolute_frame = "#{real_tmpdir}/test/my_class_test.rb:3:in `require'"
+        exc = build_load_error(
+          message: "cannot load such file -- my_class",
+          backtrace: [absolute_frame]
+        )
+        data = run_handle_load_error_in(tmpdir, exc)
+
+        expect(data["testModules"][0]["moduleId"]).to eq("test/my_class_test.rb")
+      end
+    end
+
+    it "strips the cwd prefix from absolute backtrace frames embedded in the error message" do
+      Dir.mktmpdir do |tmpdir|
+        real_tmpdir = File.realpath(tmpdir)
+        absolute_frame = "#{real_tmpdir}/test/my_class_test.rb:3:in `<top (required)>'"
+        exc = build_load_error(
+          message: "cannot load such file -- my_class",
+          backtrace: [absolute_frame]
+        )
+        data = run_handle_load_error_in(tmpdir, exc)
+
+        message = data["testModules"][0]["tests"][0]["errors"][0]["message"]
+        expect(message).to include("test/my_class_test.rb:3:in `<top (required)>'")
+        expect(message).not_to include(real_tmpdir)
+      end
+    end
+
     it "uses exception class and message as the test name" do
       Dir.mktmpdir do |tmpdir|
         exc = build_load_error(


### PR DESCRIPTION
## Summary

Normal test results pass through `extract_file_path`, which strips the cwd prefix so `moduleId` ends up like `test/foo_test.rb`. `add_load_error` pulled the path from the backtrace and only stripped a leading `./`, so absolute backtrace frames produced an absolute `moduleId` while every other entry in the same `test.json` used relative paths.

## Reproduction

In a Rails project, a spec file with `require "missing_thing"`:

| | moduleId |
|---|---|
| Before | `/Users/me/project/test/foo_test.rb` |
| After  | `test/foo_test.rb` |

The bug only manifests when the backtrace contains an absolute path (the common case under Rails, where Zeitwerk's require chain stamps absolute paths into the trace). Vanilla `ruby -Itest test/foo_test.rb` runs that emit relative backtrace frames were never affected, and remain unchanged after the fix.

## Fix

Extract a `relative_path` helper that strips a leading cwd prefix and any `./`. Call it from both `extract_file_path` (the existing path) and `add_load_error` so the format is consistent across all entries.

## Tests

Added "strips the cwd prefix from absolute backtrace paths so moduleId is relative" to the existing `.handle_load_error` group.

Closes #180.