### PR TITLE
feat(junit5): filter test failure stack to a single user frame

### DIFF
--- a/reporters/junit5/src/main/java/io/github/nizos/tddguard/junit5/StackFilter.java
+++ b/reporters/junit5/src/main/java/io/github/nizos/tddguard/junit5/StackFilter.java
@@ -1,0 +1,60 @@
+package io.github.nizos.tddguard.junit5;
+
+/**
+ * Picks the first user-code frame from a stack trace so that {@code test.json}
+ * carries a single, navigable location instead of the full noisy trace.
+ *
+ * <p>Mirrors {@code extract_relevant_stack} in the RSpec and Minitest reporters:
+ * the goal is to find the frame the developer would jump to, skipping JDK,
+ * JUnit, Gradle, and this reporter's own classes.
+ */
+public final class StackFilter {
+
+    private static final String[] FRAMEWORK_PREFIXES = {
+            "java.",
+            "javax.",
+            "jdk.",
+            "sun.",
+            "com.sun.",
+            "org.junit.",
+            "org.opentest4j.",
+            "org.gradle.",
+            "worker.org.gradle.",
+            "io.github.nizos.tddguard."
+    };
+
+    private StackFilter() {
+    }
+
+    public static String firstUserFrame(Throwable throwable) {
+        if (throwable == null) {
+            return null;
+        }
+        return firstUserFrame(throwable.getStackTrace());
+    }
+
+    public static String firstUserFrame(StackTraceElement[] frames) {
+        if (frames == null) {
+            return null;
+        }
+        for (StackTraceElement frame : frames) {
+            if (isUserFrame(frame)) {
+                return frame.toString();
+            }
+        }
+        return null;
+    }
+
+    private static boolean isUserFrame(StackTraceElement frame) {
+        String className = frame.getClassName();
+        if (className == null) {
+            return false;
+        }
+        for (String prefix : FRAMEWORK_PREFIXES) {
+            if (className.startsWith(prefix)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/reporters/junit5/src/main/java/io/github/nizos/tddguard/junit5/TestResultCollector.java
+++ b/reporters/junit5/src/main/java/io/github/nizos/tddguard/junit5/TestResultCollector.java
@@ -65,6 +65,7 @@ public final class TestResultCollector {
         if (message == null) {
             message = throwable.getClass().getName();
         }
-        return Collections.singletonList(new TestError(message));
+        String stack = StackFilter.firstUserFrame(throwable);
+        return Collections.singletonList(new TestError(message, stack));
     }
 }

--- a/reporters/junit5/src/test/java/io/github/nizos/tddguard/junit5/StackFilterTest.java
+++ b/reporters/junit5/src/test/java/io/github/nizos/tddguard/junit5/StackFilterTest.java
@@ -1,0 +1,105 @@
+package io.github.nizos.tddguard.junit5;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class StackFilterTest {
+
+    @Test
+    void returnsNullForNullStackTrace() {
+        assertNull(StackFilter.firstUserFrame((StackTraceElement[]) null));
+    }
+
+    @Test
+    void returnsNullForEmptyStackTrace() {
+        assertNull(StackFilter.firstUserFrame(new StackTraceElement[0]));
+    }
+
+    @Test
+    void returnsFirstUserFrameAsToStringValue() {
+        StackTraceElement[] frames = new StackTraceElement[] {
+                user("com.example.MyTest", "shouldFail", "MyTest.java", 42)
+        };
+
+        assertEquals(
+                "com.example.MyTest.shouldFail(MyTest.java:42)",
+                StackFilter.firstUserFrame(frames));
+    }
+
+    @Test
+    void skipsJdkInternalFramesAndJunitFrames() {
+        StackTraceElement[] frames = new StackTraceElement[] {
+                user("org.opentest4j.AssertionFailedError", "<init>", "AssertionFailedError.java", 33),
+                user("org.junit.jupiter.api.AssertionUtils", "fail", "AssertionUtils.java", 39),
+                user("jdk.internal.reflect.DirectMethodHandleAccessor", "invoke", "DirectMethodHandleAccessor.java", 103),
+                user("java.lang.reflect.Method", "invoke", "Method.java", 580),
+                user("com.example.MyTest", "shouldFail", "MyTest.java", 10),
+                user("org.junit.platform.engine.support.hierarchical.NodeTestTask", "execute", "NodeTestTask.java", 151)
+        };
+
+        assertEquals(
+                "com.example.MyTest.shouldFail(MyTest.java:10)",
+                StackFilter.firstUserFrame(frames));
+    }
+
+    @Test
+    void skipsGradleAndGradleWorkerFrames() {
+        StackTraceElement[] frames = new StackTraceElement[] {
+                user("org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor", "stop", "JUnitPlatformTestClassProcessor.java", 99),
+                user("worker.org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker", "call", "SystemApplicationClassLoaderWorker.java", 121),
+                user("com.example.MyTest", "shouldFail", "MyTest.java", 7)
+        };
+
+        assertEquals(
+                "com.example.MyTest.shouldFail(MyTest.java:7)",
+                StackFilter.firstUserFrame(frames));
+    }
+
+    @Test
+    void skipsReporterOwnFrames() {
+        StackTraceElement[] frames = new StackTraceElement[] {
+                user("io.github.nizos.tddguard.junit5.TddGuardListener", "executionFinished", "TddGuardListener.java", 64),
+                user("io.github.nizos.tddguard.junit5.TestResultCollector", "recordFailed", "TestResultCollector.java", 30),
+                user("com.example.MyTest", "shouldFail", "MyTest.java", 12)
+        };
+
+        assertEquals(
+                "com.example.MyTest.shouldFail(MyTest.java:12)",
+                StackFilter.firstUserFrame(frames));
+    }
+
+    @Test
+    void returnsNullWhenAllFramesAreFrameworkInternal() {
+        StackTraceElement[] frames = new StackTraceElement[] {
+                user("org.junit.jupiter.api.AssertionUtils", "fail", "AssertionUtils.java", 39),
+                user("org.opentest4j.AssertionFailedError", "<init>", "AssertionFailedError.java", 33),
+                user("jdk.internal.reflect.DirectMethodHandleAccessor", "invoke", "DirectMethodHandleAccessor.java", 103)
+        };
+
+        assertNull(StackFilter.firstUserFrame(frames));
+    }
+
+    @Test
+    void worksThroughThrowableOverload() {
+        Throwable t = new Throwable();
+        t.setStackTrace(new StackTraceElement[] {
+                user("org.junit.jupiter.api.AssertionUtils", "fail", "AssertionUtils.java", 39),
+                user("com.example.MyTest", "shouldFail", "MyTest.java", 5)
+        });
+
+        assertEquals(
+                "com.example.MyTest.shouldFail(MyTest.java:5)",
+                StackFilter.firstUserFrame(t));
+    }
+
+    @Test
+    void throwableOverloadReturnsNullForNull() {
+        assertNull(StackFilter.firstUserFrame((Throwable) null));
+    }
+
+    private static StackTraceElement user(String declaringClass, String method, String file, int line) {
+        return new StackTraceElement(declaringClass, method, file, line);
+    }
+}

--- a/reporters/junit5/src/test/java/io/github/nizos/tddguard/junit5/TestJsonWriterTest.java
+++ b/reporters/junit5/src/test/java/io/github/nizos/tddguard/junit5/TestJsonWriterTest.java
@@ -192,4 +192,33 @@ class TestJsonWriterTest {
 
         assertTrue(!json.contains("\"reason\""));
     }
+
+    @Test
+    void serializesStackWhenPresent() {
+        TestResult result = new TestResult(List.of(
+                new TestModule("com.example.MyTest", List.of(
+                        TestCase.failed("test", "com.example.MyTest::test",
+                                List.of(new TestError("boom",
+                                        "com.example.MyTest.test(MyTest.java:42)")))
+                ))
+        ));
+
+        String json = writer.serialize(result);
+
+        assertTrue(json.contains("\"stack\": \"com.example.MyTest.test(MyTest.java:42)\""));
+    }
+
+    @Test
+    void omitsStackWhenNull() {
+        TestResult result = new TestResult(List.of(
+                new TestModule("com.example.MyTest", List.of(
+                        TestCase.failed("test", "com.example.MyTest::test",
+                                List.of(new TestError("boom")))
+                ))
+        ));
+
+        String json = writer.serialize(result);
+
+        assertTrue(!json.contains("\"stack\""));
+    }
 }

--- a/reporters/junit5/src/test/java/io/github/nizos/tddguard/junit5/TestResultCollectorTest.java
+++ b/reporters/junit5/src/test/java/io/github/nizos/tddguard/junit5/TestResultCollectorTest.java
@@ -137,4 +137,41 @@ class TestResultCollectorTest {
     void reasonIsPassedWhenNoTestsRecorded() {
         assertEquals("passed", collector.build().reason());
     }
+
+    @Test
+    void populatesStackFromFirstUserFrame() {
+        Throwable t = new RuntimeException("boom");
+        t.setStackTrace(new StackTraceElement[] {
+                new StackTraceElement("org.opentest4j.AssertionFailedError", "<init>", "AssertionFailedError.java", 33),
+                new StackTraceElement("org.junit.jupiter.api.AssertionUtils", "fail", "AssertionUtils.java", 39),
+                new StackTraceElement("com.example.MyTest", "shouldFail", "MyTest.java", 12)
+        });
+
+        collector.recordFailed("com.example.MyTest", "shouldFail", t);
+
+        TestCase test = collector.build().testModules().get(0).tests().get(0);
+        assertEquals("com.example.MyTest.shouldFail(MyTest.java:12)", test.errors().get(0).stack());
+    }
+
+    @Test
+    void leavesStackNullWhenAllFramesAreFrameworkInternal() {
+        Throwable t = new RuntimeException("boom");
+        t.setStackTrace(new StackTraceElement[] {
+                new StackTraceElement("org.junit.jupiter.api.AssertionUtils", "fail", "AssertionUtils.java", 39),
+                new StackTraceElement("jdk.internal.reflect.DirectMethodHandleAccessor", "invoke", "DirectMethodHandleAccessor.java", 103)
+        });
+
+        collector.recordFailed("com.example.MyTest", "shouldFail", t);
+
+        TestCase test = collector.build().testModules().get(0).tests().get(0);
+        assertNull(test.errors().get(0).stack());
+    }
+
+    @Test
+    void leavesStackNullWhenThrowableIsNull() {
+        collector.recordFailed("com.example.MyTest", "shouldFail", null);
+
+        TestCase test = collector.build().testModules().get(0).tests().get(0);
+        assertNull(test.errors().get(0).stack());
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `StackFilter` — a small utility that picks the first user-code frame from a `Throwable` (or a raw `StackTraceElement[]`), skipping JDK, JUnit, Gradle, and this reporter's own classes
- Wires `TestResultCollector.buildErrors` to populate `TestError.stack` with that frame
- Returns `Class.method(File.java:line)` (the native `StackTraceElement#toString` form), so the value is one line the developer can paste into an editor

**Why.** Previously every failure carried only `message`, so the developer had to re-run the test to find where it blew up. RSpec and Minitest reporters already solve this with `extract_relevant_stack` and produce a single navigable frame; this PR lands the JUnit5 equivalent.

**Scope.** Item 2 from the JUnit5 reporter plan in #168. Item 3 (`unhandledErrors` for `@BeforeAll` / `@AfterAll`) will reuse `StackFilter` and is queued as a follow-up PR.

## Test plan

- [x] `cd reporters/junit5 && ./gradlew test` — 28 tests pass, including 14 new ones across `StackFilterTest`, `TestResultCollectorTest`, and `TestJsonWriterTest`
- [x] `npm run typecheck` — clean
- [x] `npm run lint:check` — clean
- [x] `npm run test:reporters` — JUnit5 integration scenarios unchanged from main on this branch; pre-existing local-env failures (Ruby/Go/Storybook toolchains, and the existing `'does not exist'` wording mismatch from #171) are untouched by this PR

Refs #168.