### PR TITLE
feat(junit5): skip common assertion and mocking libraries in stack filter

### DIFF
--- a/reporters/junit5/src/main/java/io/github/nizos/tddguard/junit5/StackFilter.java
+++ b/reporters/junit5/src/main/java/io/github/nizos/tddguard/junit5/StackFilter.java
@@ -20,6 +20,11 @@ public final class StackFilter {
             "org.opentest4j.",
             "org.gradle.",
             "worker.org.gradle.",
+            "org.assertj.",
+            "org.mockito.",
+            "org.hamcrest.",
+            "org.testng.",
+            "org.springframework.",
             "io.github.nizos.tddguard."
     };
 

--- a/reporters/junit5/src/test/java/io/github/nizos/tddguard/junit5/StackFilterTest.java
+++ b/reporters/junit5/src/test/java/io/github/nizos/tddguard/junit5/StackFilterTest.java
@@ -99,6 +99,45 @@ class StackFilterTest {
         assertNull(StackFilter.firstUserFrame((Throwable) null));
     }
 
+    @Test
+    void skipsAssertjMockitoHamcrestFrames() {
+        StackTraceElement[] frames = new StackTraceElement[] {
+                user("org.assertj.core.api.AbstractAssert", "isEqualTo", "AbstractAssert.java", 234),
+                user("org.mockito.internal.verification.MockAwareVerificationMode", "verify", "MockAwareVerificationMode.java", 26),
+                user("org.hamcrest.MatcherAssert", "assertThat", "MatcherAssert.java", 18),
+                user("com.example.MyTest", "shouldFail", "MyTest.java", 24)
+        };
+
+        assertEquals(
+                "com.example.MyTest.shouldFail(MyTest.java:24)",
+                StackFilter.firstUserFrame(frames));
+    }
+
+    @Test
+    void skipsTestngFrames() {
+        StackTraceElement[] frames = new StackTraceElement[] {
+                user("org.testng.Assert", "assertEquals", "Assert.java", 87),
+                user("com.example.MyTest", "shouldFail", "MyTest.java", 15)
+        };
+
+        assertEquals(
+                "com.example.MyTest.shouldFail(MyTest.java:15)",
+                StackFilter.firstUserFrame(frames));
+    }
+
+    @Test
+    void skipsSpringFrames() {
+        StackTraceElement[] frames = new StackTraceElement[] {
+                user("org.springframework.test.context.junit.jupiter.SpringExtension", "beforeEach", "SpringExtension.java", 215),
+                user("org.springframework.aop.framework.ReflectiveMethodInvocation", "proceed", "ReflectiveMethodInvocation.java", 186),
+                user("com.example.MyTest", "shouldFail", "MyTest.java", 33)
+        };
+
+        assertEquals(
+                "com.example.MyTest.shouldFail(MyTest.java:33)",
+                StackFilter.firstUserFrame(frames));
+    }
+
     private static StackTraceElement user(String declaringClass, String method, String file, int line) {
         return new StackTraceElement(declaringClass, method, file, line);
     }


### PR DESCRIPTION
## Summary

Follow-up to review feedback on #187. Extends `StackFilter.FRAMEWORK_PREFIXES` with five widely used Java testing-stack namespaces so the chosen frame is the developer's own code, not the library's internal call site:

- `org.assertj.` — AssertJ assertion frames
- `org.mockito.` — Mockito verification / stubbing frames
- `org.hamcrest.` — Hamcrest matcher frames (also used by JUnit 4 / TestNG)
- `org.testng.` — TestNG assertion frames (harmless for JUnit5-only projects)
- `org.springframework.` — Spring reflection / proxy / extension frames

**Why.** Before this change, a failure raised through e.g. `AbstractAssert#isEqualTo` would surface `org.assertj.core.api.AbstractAssert(AbstractAssert.java:234)` as the stack value — accurate but not where the developer needs to look. After this change the first non-framework frame is picked, matching the intent of the original PR.

## Test plan

- [x] `cd reporters/junit5 && ./gradlew test` — 12 `StackFilterTest` cases pass, including three new ones covering the added prefixes (`skipsAssertjMockitoHamcrestFrames`, `skipsTestngFrames`, `skipsSpringFrames`)
- [x] No behavior change for stacks that did not include these prefixes; existing tests remain green

Refs #168.