### PR TITLE
feat(junit5): capture container-level failures as unhandledErrors

### DIFF
--- a/reporters/junit5/build.gradle.kts
+++ b/reporters/junit5/build.gradle.kts
@@ -41,6 +41,11 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform()
+    // Fixture classes under the `fixtures` package are driven directly by
+    // the JUnit Platform Launcher API from integration tests. Excluding
+    // them from the regular test discovery prevents their deliberately
+    // failing hooks from breaking the outer build.
+    exclude("**/fixtures/**")
 }
 
 publishing {

--- a/reporters/junit5/src/main/java/io/github/nizos/tddguard/junit5/TddGuardListener.java
+++ b/reporters/junit5/src/main/java/io/github/nizos/tddguard/junit5/TddGuardListener.java
@@ -61,21 +61,28 @@ public final class TddGuardListener implements TestExecutionListener {
 
     @Override
     public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult result) {
-        if (collector == null || !testIdentifier.isTest()) return;
+        if (collector == null) return;
 
-        String moduleId = moduleId(testIdentifier);
-        String methodName = methodName(testIdentifier);
+        if (testIdentifier.isTest()) {
+            String moduleId = moduleId(testIdentifier);
+            String methodName = methodName(testIdentifier);
 
-        switch (result.getStatus()) {
-            case SUCCESSFUL:
-                collector.recordPassed(moduleId, methodName);
-                break;
-            case FAILED:
-            case ABORTED:
-                collector.recordFailed(moduleId, methodName, result.getThrowable().orElse(null));
-                break;
-            default:
-                break;
+            switch (result.getStatus()) {
+                case SUCCESSFUL:
+                    collector.recordPassed(moduleId, methodName);
+                    break;
+                case FAILED:
+                case ABORTED:
+                    collector.recordFailed(moduleId, methodName, result.getThrowable().orElse(null));
+                    break;
+                default:
+                    break;
+            }
+            return;
+        }
+
+        if (result.getStatus() == TestExecutionResult.Status.FAILED) {
+            result.getThrowable().ifPresent(collector::recordUnhandledError);
         }
     }
 

--- a/reporters/junit5/src/main/java/io/github/nizos/tddguard/junit5/TestJsonWriter.java
+++ b/reporters/junit5/src/main/java/io/github/nizos/tddguard/junit5/TestJsonWriter.java
@@ -4,6 +4,7 @@ import io.github.nizos.tddguard.junit5.model.TestCase;
 import io.github.nizos.tddguard.junit5.model.TestError;
 import io.github.nizos.tddguard.junit5.model.TestModule;
 import io.github.nizos.tddguard.junit5.model.TestResult;
+import io.github.nizos.tddguard.junit5.model.UnhandledError;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -45,11 +46,35 @@ public final class TestJsonWriter {
         sb.append("{\n");
         sb.append("  \"testModules\": ");
         appendModules(sb, result.testModules());
+        if (!result.unhandledErrors().isEmpty()) {
+            sb.append(",\n  \"unhandledErrors\": ");
+            appendUnhandledErrors(sb, result.unhandledErrors());
+        }
         if (result.reason() != null) {
             sb.append(",\n  \"reason\": ").append(quote(result.reason()));
         }
         sb.append("\n}\n");
         return sb.toString();
+    }
+
+    private void appendUnhandledErrors(StringBuilder sb, List<UnhandledError> errors) {
+        sb.append("[\n");
+        for (int i = 0; i < errors.size(); i++) {
+            appendUnhandledError(sb, errors.get(i));
+            if (i < errors.size() - 1) sb.append(",");
+            sb.append("\n");
+        }
+        sb.append("  ]");
+    }
+
+    private void appendUnhandledError(StringBuilder sb, UnhandledError error) {
+        sb.append("    {\n");
+        sb.append("      \"name\": ").append(quote(error.name())).append(",\n");
+        sb.append("      \"message\": ").append(quote(error.message()));
+        if (error.stack() != null) {
+            sb.append(",\n      \"stack\": ").append(quote(error.stack()));
+        }
+        sb.append("\n    }");
     }
 
     private void appendModules(StringBuilder sb, List<TestModule> modules) {

--- a/reporters/junit5/src/main/java/io/github/nizos/tddguard/junit5/TestResultCollector.java
+++ b/reporters/junit5/src/main/java/io/github/nizos/tddguard/junit5/TestResultCollector.java
@@ -4,6 +4,7 @@ import io.github.nizos.tddguard.junit5.model.TestCase;
 import io.github.nizos.tddguard.junit5.model.TestError;
 import io.github.nizos.tddguard.junit5.model.TestModule;
 import io.github.nizos.tddguard.junit5.model.TestResult;
+import io.github.nizos.tddguard.junit5.model.UnhandledError;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -18,6 +19,7 @@ import java.util.Map;
  */
 public final class TestResultCollector {
     private final Map<String, List<TestCase>> moduleMap = new LinkedHashMap<>();
+    private final List<UnhandledError> unhandledErrors = new ArrayList<>();
 
     public void recordPassed(String moduleId, String methodName) {
         add(moduleId, TestCase.passed(methodName, fullName(moduleId, methodName)));
@@ -33,6 +35,19 @@ public final class TestResultCollector {
         add(moduleId, TestCase.skipped(methodName, fullName(moduleId, methodName)));
     }
 
+    public void recordUnhandledError(Throwable throwable) {
+        if (throwable == null) {
+            return;
+        }
+        String name = throwable.getClass().getName();
+        String message = throwable.getMessage();
+        if (message == null) {
+            message = name;
+        }
+        String stack = StackFilter.firstUserFrame(throwable);
+        unhandledErrors.add(new UnhandledError(name, message, stack));
+    }
+
     public TestResult build() {
         List<TestModule> modules = new ArrayList<>();
         boolean anyFailed = false;
@@ -46,7 +61,8 @@ public final class TestResultCollector {
             }
         }
 
-        return new TestResult(modules, anyFailed ? "failed" : "passed");
+        String reason = anyFailed || !unhandledErrors.isEmpty() ? "failed" : "passed";
+        return new TestResult(modules, reason, List.copyOf(unhandledErrors));
     }
 
     private void add(String moduleId, TestCase testCase) {

--- a/reporters/junit5/src/main/java/io/github/nizos/tddguard/junit5/model/TestResult.java
+++ b/reporters/junit5/src/main/java/io/github/nizos/tddguard/junit5/model/TestResult.java
@@ -1,5 +1,6 @@
 package io.github.nizos.tddguard.junit5.model;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -11,14 +12,20 @@ import java.util.Objects;
 public final class TestResult {
     private final List<TestModule> testModules;
     private final String reason;
+    private final List<UnhandledError> unhandledErrors;
 
     public TestResult(List<TestModule> testModules) {
-        this(testModules, null);
+        this(testModules, null, Collections.emptyList());
     }
 
     public TestResult(List<TestModule> testModules, String reason) {
+        this(testModules, reason, Collections.emptyList());
+    }
+
+    public TestResult(List<TestModule> testModules, String reason, List<UnhandledError> unhandledErrors) {
         this.testModules = Objects.requireNonNull(testModules, "testModules must not be null");
         this.reason = reason;
+        this.unhandledErrors = Objects.requireNonNull(unhandledErrors, "unhandledErrors must not be null");
     }
 
     public List<TestModule> testModules() {
@@ -27,5 +34,9 @@ public final class TestResult {
 
     public String reason() {
         return reason;
+    }
+
+    public List<UnhandledError> unhandledErrors() {
+        return unhandledErrors;
     }
 }

--- a/reporters/junit5/src/main/java/io/github/nizos/tddguard/junit5/model/UnhandledError.java
+++ b/reporters/junit5/src/main/java/io/github/nizos/tddguard/junit5/model/UnhandledError.java
@@ -1,0 +1,36 @@
+package io.github.nizos.tddguard.junit5.model;
+
+import java.util.Objects;
+
+/**
+ * Error raised outside of any test method, typically from a JUnit5
+ * {@code @BeforeAll} or {@code @AfterAll} hook. Maps to a single entry
+ * in {@code test.json}'s top-level {@code unhandledErrors} array.
+ */
+public final class UnhandledError {
+    private final String name;
+    private final String message;
+    private final String stack;
+
+    public UnhandledError(String name, String message) {
+        this(name, message, null);
+    }
+
+    public UnhandledError(String name, String message, String stack) {
+        this.name = Objects.requireNonNull(name, "name must not be null");
+        this.message = Objects.requireNonNull(message, "message must not be null");
+        this.stack = stack;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public String message() {
+        return message;
+    }
+
+    public String stack() {
+        return stack;
+    }
+}

--- a/reporters/junit5/src/test/java/io/github/nizos/tddguard/junit5/TddGuardListenerTest.java
+++ b/reporters/junit5/src/test/java/io/github/nizos/tddguard/junit5/TddGuardListenerTest.java
@@ -16,6 +16,7 @@ import java.nio.file.Path;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+
 class TddGuardListenerTest {
 
     private static final String DATA_PATH = ".claude/tdd-guard/data/test.json";
@@ -85,7 +86,7 @@ class TddGuardListenerTest {
     }
 
     @Test
-    void ignoresContainerEvents(@TempDir Path tmp) throws IOException {
+    void ignoresSuccessfulContainerEvents(@TempDir Path tmp) throws IOException {
         TddGuardListener listener = createListener(tmp, name -> tmp.toString());
 
         listener.testPlanExecutionStarted(null);
@@ -95,6 +96,23 @@ class TddGuardListenerTest {
 
         String content = Files.readString(tmp.resolve(DATA_PATH));
         assertTrue(content.contains("\"testModules\": []"));
+        assertFalse(content.contains("\"unhandledErrors\""));
+    }
+
+    @Test
+    void capturesFailedContainerAsUnhandledError(@TempDir Path tmp) throws IOException {
+        TddGuardListener listener = createListener(tmp, name -> tmp.toString());
+
+        listener.testPlanExecutionStarted(null);
+        listener.executionFinished(containerIdentifier("com.example.MyTest"),
+                TestExecutionResult.failed(new RuntimeException("@AfterAll exploded")));
+        listener.testPlanExecutionFinished(null);
+
+        String content = Files.readString(tmp.resolve(DATA_PATH));
+        assertTrue(content.contains("\"unhandledErrors\""));
+        assertTrue(content.contains("\"name\": \"java.lang.RuntimeException\""));
+        assertTrue(content.contains("\"message\": \"@AfterAll exploded\""));
+        assertTrue(content.contains("\"reason\": \"failed\""));
     }
 
     @Test

--- a/reporters/junit5/src/test/java/io/github/nizos/tddguard/junit5/TestJsonWriterTest.java
+++ b/reporters/junit5/src/test/java/io/github/nizos/tddguard/junit5/TestJsonWriterTest.java
@@ -4,6 +4,7 @@ import io.github.nizos.tddguard.junit5.model.TestCase;
 import io.github.nizos.tddguard.junit5.model.TestError;
 import io.github.nizos.tddguard.junit5.model.TestModule;
 import io.github.nizos.tddguard.junit5.model.TestResult;
+import io.github.nizos.tddguard.junit5.model.UnhandledError;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -219,6 +220,48 @@ class TestJsonWriterTest {
 
         String json = writer.serialize(result);
 
+        assertTrue(!json.contains("\"stack\""));
+    }
+
+    @Test
+    void serializesUnhandledErrorsWhenPresent() {
+        TestResult result = new TestResult(
+                Collections.emptyList(),
+                "failed",
+                List.of(new UnhandledError(
+                        "java.lang.RuntimeException",
+                        "teardown blew up",
+                        "com.example.MyTest.tearDownAll(MyTest.java:31)"))
+        );
+
+        String json = writer.serialize(result);
+
+        assertTrue(json.contains("\"unhandledErrors\": ["));
+        assertTrue(json.contains("\"name\": \"java.lang.RuntimeException\""));
+        assertTrue(json.contains("\"message\": \"teardown blew up\""));
+        assertTrue(json.contains("\"stack\": \"com.example.MyTest.tearDownAll(MyTest.java:31)\""));
+    }
+
+    @Test
+    void omitsUnhandledErrorsKeyWhenListIsEmpty() {
+        TestResult result = new TestResult(Collections.emptyList());
+
+        String json = writer.serialize(result);
+
+        assertTrue(!json.contains("\"unhandledErrors\""));
+    }
+
+    @Test
+    void omitsUnhandledErrorStackWhenNull() {
+        TestResult result = new TestResult(
+                Collections.emptyList(),
+                "failed",
+                List.of(new UnhandledError("java.lang.RuntimeException", "boom"))
+        );
+
+        String json = writer.serialize(result);
+
+        assertTrue(json.contains("\"unhandledErrors\": ["));
         assertTrue(!json.contains("\"stack\""));
     }
 }

--- a/reporters/junit5/src/test/java/io/github/nizos/tddguard/junit5/TestResultCollectorTest.java
+++ b/reporters/junit5/src/test/java/io/github/nizos/tddguard/junit5/TestResultCollectorTest.java
@@ -3,6 +3,7 @@ package io.github.nizos.tddguard.junit5;
 import io.github.nizos.tddguard.junit5.model.TestCase;
 import io.github.nizos.tddguard.junit5.model.TestModule;
 import io.github.nizos.tddguard.junit5.model.TestResult;
+import io.github.nizos.tddguard.junit5.model.UnhandledError;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -173,5 +174,63 @@ class TestResultCollectorTest {
 
         TestCase test = collector.build().testModules().get(0).tests().get(0);
         assertNull(test.errors().get(0).stack());
+    }
+
+    @Test
+    void buildHasEmptyUnhandledErrorsByDefault() {
+        assertTrue(collector.build().unhandledErrors().isEmpty());
+    }
+
+    @Test
+    void recordUnhandledErrorCapturesClassMessageAndStack() {
+        Throwable t = new RuntimeException("teardown blew up");
+        t.setStackTrace(new StackTraceElement[] {
+                new StackTraceElement("org.junit.jupiter.engine.execution.ExecutableInvoker", "invoke", "ExecutableInvoker.java", 115),
+                new StackTraceElement("com.example.MyTest", "tearDownAll", "MyTest.java", 31)
+        });
+
+        collector.recordUnhandledError(t);
+
+        List<UnhandledError> errors = collector.build().unhandledErrors();
+        assertEquals(1, errors.size());
+        UnhandledError error = errors.get(0);
+        assertEquals("java.lang.RuntimeException", error.name());
+        assertEquals("teardown blew up", error.message());
+        assertEquals("com.example.MyTest.tearDownAll(MyTest.java:31)", error.stack());
+    }
+
+    @Test
+    void recordUnhandledErrorFallsBackToClassNameWhenMessageIsNull() {
+        collector.recordUnhandledError(new NullPointerException());
+
+        UnhandledError error = collector.build().unhandledErrors().get(0);
+        assertEquals("java.lang.NullPointerException", error.name());
+        assertEquals("java.lang.NullPointerException", error.message());
+    }
+
+    @Test
+    void recordUnhandledErrorIgnoresNullThrowable() {
+        collector.recordUnhandledError(null);
+
+        assertTrue(collector.build().unhandledErrors().isEmpty());
+    }
+
+    @Test
+    void recordUnhandledErrorAppendsInOrder() {
+        collector.recordUnhandledError(new RuntimeException("first"));
+        collector.recordUnhandledError(new IllegalStateException("second"));
+
+        List<UnhandledError> errors = collector.build().unhandledErrors();
+        assertEquals(2, errors.size());
+        assertEquals("first", errors.get(0).message());
+        assertEquals("second", errors.get(1).message());
+    }
+
+    @Test
+    void reasonIsFailedWhenOnlyUnhandledErrorsPresent() {
+        collector.recordPassed("com.example.MyTest", "a");
+        collector.recordUnhandledError(new RuntimeException("hook failure"));
+
+        assertEquals("failed", collector.build().reason());
     }
 }

--- a/reporters/junit5/src/test/java/io/github/nizos/tddguard/junit5/UnhandledErrorsIntegrationTest.java
+++ b/reporters/junit5/src/test/java/io/github/nizos/tddguard/junit5/UnhandledErrorsIntegrationTest.java
@@ -1,0 +1,56 @@
+package io.github.nizos.tddguard.junit5;
+
+import io.github.nizos.tddguard.junit5.fixtures.AfterAllFailingFixture;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.launcher.Launcher;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.core.LauncherFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Drives the JUnit Platform Launcher API end-to-end against a fixture whose
+ * {@code @AfterAll} hook throws, mirroring the Ruby reporters'
+ * {@code unhandled_errors_integration_spec.rb}. Detects regressions if
+ * JUnit Platform changes how container-level failures are surfaced.
+ */
+class UnhandledErrorsIntegrationTest {
+
+    @Test
+    void capturesAfterAllHookFailureAsUnhandledError(@TempDir Path tmp) throws IOException {
+        TddGuardListener listener = new TddGuardListener(
+                new ProjectRootResolver(name -> tmp.toString(), () -> tmp),
+                new TestJsonWriter(),
+                name -> tmp.toString());
+
+        LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request()
+                .selectors(DiscoverySelectors.selectClass(AfterAllFailingFixture.class))
+                .build();
+
+        Launcher launcher = LauncherFactory.create();
+        launcher.execute(request, listener);
+
+        Path testJson = tmp.resolve(".claude/tdd-guard/data/test.json");
+        assertTrue(Files.exists(testJson),
+                "test.json was not written — listener wiring may be broken");
+        String content = Files.readString(testJson);
+
+        assertTrue(content.contains("\"unhandledErrors\""),
+                "unhandledErrors key missing — container failure capture may be broken");
+        assertTrue(content.contains("\"name\": \"java.lang.RuntimeException\""),
+                "expected RuntimeException name in unhandled error");
+        assertTrue(content.contains("\"message\": \"@AfterAll exploded\""),
+                "expected the original @AfterAll exception message");
+        assertTrue(content.contains("\"reason\": \"failed\""),
+                "reason should be failed when unhandledErrors are present");
+        assertTrue(content.contains("\"state\": \"passed\""),
+                "the passing test inside the fixture should still appear as passed");
+    }
+}

--- a/reporters/junit5/src/test/java/io/github/nizos/tddguard/junit5/fixtures/AfterAllFailingFixture.java
+++ b/reporters/junit5/src/test/java/io/github/nizos/tddguard/junit5/fixtures/AfterAllFailingFixture.java
@@ -1,0 +1,26 @@
+package io.github.nizos.tddguard.junit5.fixtures;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Fixture executed by {@code UnhandledErrorsIntegrationTest} via the
+ * JUnit Platform Launcher API. Not part of the regular test suite —
+ * excluded from {@code ./gradlew test} via {@code tasks.test.exclude}
+ * in {@code build.gradle.kts} so the deliberately failing {@code @AfterAll}
+ * hook does not break the outer build.
+ */
+public class AfterAllFailingFixture {
+
+    @Test
+    void shouldPass() {
+        assertEquals(5, 2 + 3);
+    }
+
+    @AfterAll
+    static void teardownThatFails() {
+        throw new RuntimeException("@AfterAll exploded");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an `UnhandledError` model and a `TestResultCollector.recordUnhandledError` path that reuses `StackFilter` for the stack value
- Forwards a container's `FAILED` `executionFinished` to that path so `@BeforeAll` / `@AfterAll` failures land in `test.json`'s top-level `unhandledErrors` array
- Treats a non-empty `unhandledErrors` list as a `"failed"` reason, matching the RSpec reporter

**Why.** Before this change a failing `@BeforeAll` / `@AfterAll` only surfaced in JUnit's own output, so a green test class with a broken teardown looked clean in `test.json`. This brings JUnit5 in line with how RSpec and Minitest expose suite-level failures.

**Scope.** Item 3 from the JUnit5 reporter plan in #168. Item 4 (interrupted run detection) will reuse this reason-resolution path and is queued as a follow-up.

## Test plan

- [x] `cd reporters/junit5 && ./gradlew test` — 87 tests pass, including a new `UnhandledErrorsIntegrationTest` that drives a fixture with a throwing `@AfterAll` through the JUnit Platform Launcher API
- [x] `npm run typecheck` and `npm run lint:check` — clean
- [x] Existing successful-container path unchanged; `ignoresContainerEvents` is split into a positive and negative case

Refs #168.