### PR TITLE
feat(dotnet): add core reporter (listener, collector, writer, SPI hook)

### DIFF
--- a/reporters/dotnet/.gitignore
+++ b/reporters/dotnet/.gitignore
@@ -1,0 +1,5 @@
+bin/
+obj/
+.claude/
+.idea/
+*.user

--- a/reporters/dotnet/.globalconfig
+++ b/reporters/dotnet/.globalconfig
@@ -1,0 +1,22 @@
+is_global = true
+
+# Nested types are used intentionally for discriminated unions (TestState, WriteResult)
+dotnet_diagnostic.CA1034.severity = none
+
+# WriteResult.Error naming is intentional for the result type pattern
+dotnet_diagnostic.CA1716.severity = none
+
+# Serialization class name conflict with System.ComponentModel.Design.Serialization is not a real concern
+dotnet_diagnostic.CA1724.severity = none
+
+# TestResultsWriter intentionally catches all exceptions to convert to WriteResult.Error
+dotnet_diagnostic.CA1031.severity = none
+
+# DataTypesConsumed is an MTP interface that requires returning Type[]
+dotnet_diagnostic.CA1819.severity = none
+
+# Nullable reference types make CA1062 redundant; the compiler enforces non-null at call sites
+dotnet_diagnostic.CA1062.severity = none
+
+# ConfigureAwait is unnecessary in app/test code without a SynchronizationContext
+dotnet_diagnostic.CA2007.severity = none

--- a/reporters/dotnet/Directory.Build.props
+++ b/reporters/dotnet/Directory.Build.props
@@ -1,0 +1,10 @@
+<Project>
+
+  <PropertyGroup>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>latest-All</AnalysisLevel>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+</Project>

--- a/reporters/dotnet/README.md
+++ b/reporters/dotnet/README.md
@@ -1,0 +1,124 @@
+# TDD Guard .NET Reporter
+
+Microsoft Testing Platform (MTP) V2 extension that captures test results
+for TDD Guard validation. Works with any .NET test framework that supports
+MTP V2 — one package covers TUnit, MSTest, xUnit, NUnit, and more.
+
+## How it works
+
+The reporter is an MTP V2 extension that loads in-process alongside your
+test framework. It subscribes to `TestNodeUpdateMessage` events — the
+standard MTP event type that all frameworks publish when a test completes.
+
+When a test session finishes, the extension writes results to
+`.claude/tdd-guard/data/test.json` in the TDD Guard wire format. The
+TDD Guard validation hook reads this file to enforce TDD discipline.
+
+The extension is framework-agnostic. It does not know or care which
+framework is running. MTP handles the framework integration; we handle
+the test result capture.
+
+## Requirements
+
+- .NET 10+
+- [TDD Guard](https://github.com/nizos/tdd-guard)
+
+## Installation
+
+Planned distribution: NuGet.org (published by the maintainer).
+
+Add a PackageReference to your test project:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="TddGuard.Dotnet" Version="*" />
+</ItemGroup>
+```
+
+For solutions with multiple test projects, add it once via
+`Directory.Build.props` in your tests directory:
+
+```xml
+<Project>
+  <ItemGroup>
+    <PackageReference Include="TddGuard.Dotnet" Version="*" />
+  </ItemGroup>
+</Project>
+```
+
+No manual hook code is needed — the package auto-registers via
+`buildTransitive/*.props` which injects the MTP builder hook at build time.
+
+## Usage
+
+The extension registers automatically. Running `dotnet test` is enough
+once the package is referenced.
+
+## Configuration
+
+### Project Root
+
+Set the `TDD_GUARD_PROJECT_ROOT` environment variable to your project root:
+
+```bash
+export TDD_GUARD_PROJECT_ROOT="/absolute/path/to/project/root"
+```
+
+`CLAUDE_PROJECT_DIR` is used as a fallback when `TDD_GUARD_PROJECT_ROOT`
+is not set. Claude Code sets this variable for hook commands, though it
+may not be available in all execution contexts.
+
+### Rules
+
+- Absolute and relative paths are both accepted (per ADR-009)
+- Current directory must be within the configured project root
+- When neither env var is set, the extension logs a diagnostic to stderr
+  and disables itself (per ADR-010) — it does not silently fall back to cwd
+
+## Compatibility
+
+Verified with smoke tests in `TddGuard.Dotnet.Compat.*` projects:
+
+| Framework                                        | MTP V2 support | Status   | Notes                                            |
+| ------------------------------------------------ | -------------- | -------- | ------------------------------------------------ |
+| [TUnit](https://github.com/thomhurst/TUnit)      | Native         | Verified | File path as module ID                           |
+| [MSTest v4](https://github.com/microsoft/testfx) | Native         | Verified | File path as module ID                           |
+| [xUnit v3](https://xunit.net/)                   | Native         | Verified | Via `xunit.v3.mtp-v2` package                    |
+| [xUnit v2](https://xunit.net/)                   | Via adapter    | Verified | Via `YTest.MTP.XUnit2` (third-party, unofficial) |
+| [NUnit 4](https://docs.nunit.org/)               | Via runner     | Verified | UID as module ID (NUnit omits file paths)        |
+| [Reqnroll](https://reqnroll.net/)                | Inherited      | Expected | BDD layer over MSTest/NUnit/xUnit/TUnit          |
+
+## Project structure
+
+```
+TddGuard.Dotnet.Core/       Domain types and pure functions (no MTP dependency)
+TddGuard.Dotnet/             MTP V2 extension (listener, builder, hook)
+TddGuard.Dotnet.Tests/       Unit tests, property-based tests, test infrastructure
+TddGuard.Dotnet.Compat.*/    Framework compatibility smoke tests
+```
+
+`Core` has no dependency on MTP. It defines the domain types
+(`TestState`, `CollectedResult`, `TestRunOutput`), the serializer,
+the file writer, and the project root resolver. `Dotnet` depends on
+Core and MTP, wiring the domain logic into the MTP extension model.
+
+This separation means the domain logic can be tested without MTP,
+and the MTP integration can change without affecting the domain.
+
+## Development
+
+All commands run inside the devcontainer:
+
+```bash
+docker exec -w /workspace/reporters/dotnet <container> dotnet build
+docker exec -w /workspace/reporters/dotnet <container> dotnet test --project TddGuard.Dotnet.Tests
+```
+
+Find the container name via `docker ps`.
+
+See `TddGuard.Dotnet.Tests/README.md` for testing conventions,
+infrastructure, and the framework smoke test guide.
+
+## License
+
+MIT

--- a/reporters/dotnet/TddGuard.Dotnet.Core/Diagnostics.cs
+++ b/reporters/dotnet/TddGuard.Dotnet.Core/Diagnostics.cs
@@ -1,0 +1,38 @@
+using OneOf;
+
+namespace TddGuard.Dotnet.Core;
+
+/// <summary>
+/// Decorators that add diagnostic logging to core operations.
+/// Composed at bootstrap time, not at definition time.
+/// </summary>
+public static class Diagnostics
+{
+    /// <summary>
+    /// Logs a diagnostic message when project root resolution fails.
+    /// Passes through both success and error tracks unchanged.
+    /// </summary>
+    public static OneOf<ProjectRoot, ResolveError> LogOnError(
+        this OneOf<ProjectRoot, ResolveError> result,
+        LogDiagnostic log)
+    {
+        result.Switch(_ => { }, error => log($"disabled: {error.Reason}"));
+        return result;
+    }
+
+    /// <summary>
+    /// Wraps a <see cref="WriteTestOutput"/> delegate to log on write failure.
+    /// </summary>
+    public static WriteTestOutput WithDiagnostics(
+        this WriteTestOutput inner,
+        LogDiagnostic log)
+    {
+        return output =>
+        {
+            var result = inner(output);
+            if (result is WriteResult.Error e)
+                log($"failed to write test.json: {e.Message}");
+            return result;
+        };
+    }
+}

--- a/reporters/dotnet/TddGuard.Dotnet.Core/OutputTypes.cs
+++ b/reporters/dotnet/TddGuard.Dotnet.Core/OutputTypes.cs
@@ -1,0 +1,16 @@
+namespace TddGuard.Dotnet.Core;
+
+/// <summary>
+/// Wire-format types serialised to <c>test.json</c>.
+/// Field names match the TDD Guard Zod schema after camelCase conversion.
+/// </summary>
+public record TestRunOutput(IReadOnlyList<TestModuleOutput> TestModules, string? Reason);
+
+/// <summary>A group of tests sharing the same source file (module).</summary>
+public record TestModuleOutput(string ModuleId, IReadOnlyList<TestEntryOutput> Tests);
+
+/// <summary>A single test entry in the JSON output.</summary>
+public record TestEntryOutput(string Name, string FullName, string State, IReadOnlyList<TestEntryErrorOutput>? Errors);
+
+/// <summary>An error message attached to a failing test entry.</summary>
+public record TestEntryErrorOutput(string Message);

--- a/reporters/dotnet/TddGuard.Dotnet.Core/Ports.cs
+++ b/reporters/dotnet/TddGuard.Dotnet.Core/Ports.cs
@@ -1,0 +1,24 @@
+namespace TddGuard.Dotnet.Core;
+
+/// <summary>
+/// Named delegate for environment variable lookup, replacing <c>Func&lt;string, string?&gt;</c>
+/// for readability at call sites.
+/// </summary>
+public delegate string? GetEnvironmentVariable(string name);
+
+/// <summary>
+/// Port delegate that writes a completed test run to persistent storage.
+/// Returns errors as values rather than throwing exceptions.
+/// </summary>
+public delegate WriteResult WriteTestOutput(TestRunOutput output);
+
+/// <summary>
+/// Named delegate for retrieving the current working directory.
+/// </summary>
+public delegate string GetCurrentWorkingDirectory();
+
+/// <summary>
+/// Port delegate for diagnostic messages (resolve failures, write errors).
+/// Production default writes to stderr with a <c>[tdd-guard-dotnet]</c> prefix.
+/// </summary>
+public delegate void LogDiagnostic(string message);

--- a/reporters/dotnet/TddGuard.Dotnet.Core/ProjectRootResolver.cs
+++ b/reporters/dotnet/TddGuard.Dotnet.Core/ProjectRootResolver.cs
@@ -1,0 +1,69 @@
+using OneOf;
+
+namespace TddGuard.Dotnet.Core;
+
+public record ProjectRoot(string Path);
+public record ResolveError(string Reason);
+
+/// <summary>
+/// Resolves the project root directory used as the base path for writing
+/// <c>.claude/tdd-guard/data/test.json</c>.
+/// Checks <c>TDD_GUARD_PROJECT_ROOT</c>, then <c>CLAUDE_PROJECT_DIR</c>.
+/// Returns a <see cref="ResolveError"/> when neither env var is set (per ADR-010)
+/// or when the working directory is outside the resolved root, allowing callers
+/// to gracefully disable instead of crashing.
+/// </summary>
+public static class ProjectRootResolver
+{
+    public static OneOf<ProjectRoot, ResolveError> Resolve(
+        GetEnvironmentVariable getEnvVar,
+        GetCurrentWorkingDirectory getCwd)
+    {
+        var raw = getEnvVar("TDD_GUARD_PROJECT_ROOT")
+            ?? getEnvVar("CLAUDE_PROJECT_DIR");
+
+        if (string.IsNullOrEmpty(raw))
+            return new ResolveError("No project root configured (set TDD_GUARD_PROJECT_ROOT)");
+
+        var root = ResolvePath(raw);
+        var cwd = ResolvePath(getCwd());
+
+        if (!IsDescendantOf(cwd, root))
+            return new ResolveError($"Working directory '{cwd}' is not within project root '{root}'");
+
+        return new ProjectRoot(root);
+    }
+
+    private static bool IsDescendantOf(string child, string parent)
+    {
+        var normalizedParent = parent.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            + Path.DirectorySeparatorChar;
+        var normalizedChild = child.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            + Path.DirectorySeparatorChar;
+
+        // Case-insensitive to match Windows path semantics and .NET's own Path behaviour.
+        // On case-sensitive Linux filesystems this is technically lenient, but consistent
+        // with how Directory.GetCurrentDirectory() and Path.GetFullPath() normalise paths.
+        return normalizedChild.StartsWith(normalizedParent, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Resolves a path to its canonical form: absolute, normalised, and with
+    /// symlinks resolved. Handles macOS /var -> /private/var and similar.
+    /// Falls back to <see cref="Path.GetFullPath"/> when the path does not exist.
+    /// </summary>
+    private static string ResolvePath(string path)
+    {
+        var full = Path.GetFullPath(path);
+        try
+        {
+            var info = new DirectoryInfo(full);
+            var target = info.ResolveLinkTarget(returnFinalTarget: true);
+            return target?.FullName ?? full;
+        }
+        catch (IOException)
+        {
+            return full;
+        }
+    }
+}

--- a/reporters/dotnet/TddGuard.Dotnet.Core/ReportFileWriter.cs
+++ b/reporters/dotnet/TddGuard.Dotnet.Core/ReportFileWriter.cs
@@ -1,0 +1,37 @@
+namespace TddGuard.Dotnet.Core;
+
+/// <summary>
+/// Creates a <see cref="WriteTestOutput"/> delegate that writes serialised test output
+/// to <c>{projectRoot}/.claude/tdd-guard/data/test.json</c>.
+/// Uses atomic write (temp file + rename) to prevent partial reads.
+/// </summary>
+public static class ReportFileWriter
+{
+    private const string DataPath = ".claude/tdd-guard/data";
+    private const string FileName = "test.json";
+
+    public static WriteTestOutput Create(string projectRoot)
+    {
+        return output =>
+        {
+            try
+            {
+                var dir = Path.Combine(projectRoot, DataPath);
+                Directory.CreateDirectory(dir);
+
+                var targetPath = Path.Combine(dir, FileName);
+                var tempPath = targetPath + ".tmp";
+
+                var json = output.Serialize();
+                File.WriteAllText(tempPath, json);
+                File.Move(tempPath, targetPath, overwrite: true);
+
+                return new WriteResult.Success();
+            }
+            catch (Exception ex)
+            {
+                return new WriteResult.Error(ex.ToString());
+            }
+        };
+    }
+}

--- a/reporters/dotnet/TddGuard.Dotnet.Core/TddGuard.Dotnet.Core.csproj
+++ b/reporters/dotnet/TddGuard.Dotnet.Core/TddGuard.Dotnet.Core.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>true</IsPackable>
+    <Version>0.1.0</Version>
+    <Authors>Ed Blackburn</Authors>
+    <RepositoryUrl>https://github.com/nizos/tdd-guard</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OneOf" Version="3.*" />
+  </ItemGroup>
+
+</Project>

--- a/reporters/dotnet/TddGuard.Dotnet.Core/TestNodeMapper.cs
+++ b/reporters/dotnet/TddGuard.Dotnet.Core/TestNodeMapper.cs
@@ -1,0 +1,19 @@
+namespace TddGuard.Dotnet.Core;
+
+/// <summary>
+/// Maps raw MTP test node input into a <see cref="CollectedResult"/>,
+/// extracting the full name from the UID and using the file path as module ID.
+/// </summary>
+public static class TestNodeMapper
+{
+    public static CollectedResult ToCollectedResult(this TestNodeInput input)
+    {
+        // MTP UIDs include test parameters: "assembly/Namespace.Class/Method(param1, param2)".
+        // Strip from the first '(' so fullName is the stable method identifier.
+        var uid = input.Uid;
+        var parenIndex = uid.IndexOf('(', StringComparison.Ordinal);
+        var fullName = parenIndex >= 0 ? uid[..parenIndex] : uid;
+
+        return new CollectedResult(input.DisplayName, fullName, input.FilePath ?? fullName, input.State);
+    }
+}

--- a/reporters/dotnet/TddGuard.Dotnet.Core/TestReportSerializer.cs
+++ b/reporters/dotnet/TddGuard.Dotnet.Core/TestReportSerializer.cs
@@ -1,0 +1,23 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace TddGuard.Dotnet.Core;
+
+/// <summary>
+/// Serialises <see cref="TestRunOutput"/> to compact camelCase JSON,
+/// omitting null properties to match the TDD Guard wire format.
+/// </summary>
+public static class TestReportSerializer
+{
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = false,
+    };
+
+    public static string Serialize(this TestRunOutput output)
+    {
+        return JsonSerializer.Serialize(output, Options);
+    }
+}

--- a/reporters/dotnet/TddGuard.Dotnet.Core/TestReportWriter.cs
+++ b/reporters/dotnet/TddGuard.Dotnet.Core/TestReportWriter.cs
@@ -1,0 +1,20 @@
+namespace TddGuard.Dotnet.Core;
+
+/// <summary>
+/// Orchestrates the final step of a test session: summarises collected results
+/// and delegates to the <see cref="WriteTestOutput"/> port.
+/// Skips writing when no results were collected.
+/// </summary>
+public static class TestReportWriter
+{
+    public static WriteResult WriteTestReport(
+        this IReadOnlyCollection<CollectedResult> results,
+        WriteTestOutput writeOutput)
+    {
+        if (results.Count == 0)
+            return new WriteResult.Skipped();
+
+        var output = results.Summarise();
+        return writeOutput(output);
+    }
+}

--- a/reporters/dotnet/TddGuard.Dotnet.Core/TestRunSummariser.cs
+++ b/reporters/dotnet/TddGuard.Dotnet.Core/TestRunSummariser.cs
@@ -1,0 +1,34 @@
+namespace TddGuard.Dotnet.Core;
+
+/// <summary>
+/// Groups collected test results by module and converts them into
+/// the wire-format <see cref="TestRunOutput"/> for JSON serialisation.
+/// Pure function with no side effects.
+/// </summary>
+public static class TestRunSummariser
+{
+    public static TestRunOutput Summarise(this IReadOnlyCollection<CollectedResult> results)
+    {
+        var modules = results
+            .GroupBy(r => r.ModuleId)
+            .Select(g => new TestModuleOutput(
+                ModuleId: g.Key,
+                Tests: g.Select(r => r.State switch
+                {
+                    TestState.Passed => new TestEntryOutput(r.Name, r.FullName, "passed", null),
+                    TestState.Failed f => new TestEntryOutput(r.Name, r.FullName, "failed",
+                        f.Errors.Select(e => new TestEntryErrorOutput(e.Message)).ToList()),
+                    TestState.Skipped => new TestEntryOutput(r.Name, r.FullName, "skipped", null),
+                    // Unreachable: TestState is a sealed DU with 3 variants. C# pattern matching
+                    // cannot prove exhaustiveness on sealed abstract records, so this satisfies the compiler.
+                    _ => throw new InvalidOperationException($"Unknown TestState: {r.State}")
+                }).ToList()))
+            .ToList();
+
+        var reason = results.Any(r => r.State is TestState.Failed)
+            ? "failed"
+            : "passed";
+
+        return new TestRunOutput(modules, reason);
+    }
+}

--- a/reporters/dotnet/TddGuard.Dotnet.Core/TestTypes.cs
+++ b/reporters/dotnet/TddGuard.Dotnet.Core/TestTypes.cs
@@ -1,0 +1,28 @@
+namespace TddGuard.Dotnet.Core;
+
+/// <summary>
+/// Sealed discriminated union representing the outcome of a single test.
+/// </summary>
+public abstract record TestState
+{
+    private TestState() { }
+
+    public sealed record Passed : TestState;
+    public sealed record Failed(IReadOnlyList<TestEntryError> Errors) : TestState;
+    public sealed record Skipped : TestState;
+}
+
+/// <summary>Error message captured from a failed test assertion or exception.</summary>
+public record TestEntryError(string Message);
+
+/// <summary>
+/// Raw input from the MTP test node, before module grouping.
+/// Decoupled from MTP types so Core has no platform dependency.
+/// </summary>
+public record TestNodeInput(string Uid, string DisplayName, string? FilePath, TestState State);
+
+/// <summary>
+/// Processed test result after UID parsing and module assignment.
+/// Produced by <see cref="TestNodeMapper.ToCollectedResult"/>.
+/// </summary>
+public record CollectedResult(string Name, string FullName, string ModuleId, TestState State);

--- a/reporters/dotnet/TddGuard.Dotnet.Core/WriteResult.cs
+++ b/reporters/dotnet/TddGuard.Dotnet.Core/WriteResult.cs
@@ -1,0 +1,14 @@
+namespace TddGuard.Dotnet.Core;
+
+/// <summary>
+/// Sealed discriminated union for file-write outcomes.
+/// Errors are returned as values rather than thrown as exceptions.
+/// </summary>
+public abstract record WriteResult
+{
+    private WriteResult() { }
+
+    public sealed record Success : WriteResult;
+    public sealed record Skipped : WriteResult;
+    public sealed record Error(string Message) : WriteResult;
+}

--- a/reporters/dotnet/TddGuard.Dotnet.Tests/DiagnosticDecoratorTests.cs
+++ b/reporters/dotnet/TddGuard.Dotnet.Tests/DiagnosticDecoratorTests.cs
@@ -1,0 +1,89 @@
+using OneOf;
+using TddGuard.Dotnet.Core;
+
+namespace TddGuard.Dotnet.Tests;
+
+internal sealed class DiagnosticDecoratorTests
+{
+    [Test("LogOnError logs message when result is ResolveError")]
+    public async Task LogOnErrorLogsOnFailure()
+    {
+        string? captured = null;
+        OneOf<ProjectRoot, ResolveError> result = new ResolveError("bad path");
+
+        result.LogOnError(msg => captured = msg);
+
+        await Assert.That(captured).IsNotNull();
+        await Assert.That(captured!).Contains("bad path");
+    }
+
+    [Test("LogOnError does not log when result is ProjectRoot")]
+    public async Task LogOnErrorDoesNotLogOnSuccess()
+    {
+        string? captured = null;
+        OneOf<ProjectRoot, ResolveError> result = new ProjectRoot("/valid");
+
+        result.LogOnError(msg => captured = msg);
+
+        await Assert.That(captured).IsNull();
+    }
+
+    [Test("WithDiagnostics logs message when write returns Error")]
+    public async Task WithDiagnosticsLogsOnWriteError()
+    {
+        string? captured = null;
+        WriteTestOutput inner = _ => new WriteResult.Error("disk full");
+        var decorated = inner.WithDiagnostics(msg => captured = msg);
+
+        decorated(new TestRunOutput([], "passed"));
+
+        await Assert.That(captured).IsNotNull();
+        await Assert.That(captured!).Contains("disk full");
+    }
+
+    [Test("WithDiagnostics does not log when write succeeds")]
+    public async Task WithDiagnosticsDoesNotLogOnSuccess()
+    {
+        string? captured = null;
+        WriteTestOutput inner = _ => new WriteResult.Success();
+        var decorated = inner.WithDiagnostics(msg => captured = msg);
+
+        decorated(new TestRunOutput([], "passed"));
+
+        await Assert.That(captured).IsNull();
+    }
+
+    [Test("LogOnError returns the error result unchanged")]
+    public async Task LogOnErrorReturnsErrorResultUnchanged()
+    {
+        OneOf<ProjectRoot, ResolveError> error = new ResolveError("bad");
+
+        var result = error.LogOnError(_ => { });
+
+        await Assert.That(result.IsT1).IsTrue();
+        await Assert.That(result.AsT1.Reason).IsEqualTo("bad");
+    }
+
+    [Test("LogOnError returns the success result unchanged")]
+    public async Task LogOnErrorReturnsSuccessResultUnchanged()
+    {
+        OneOf<ProjectRoot, ResolveError> success = new ProjectRoot("/valid");
+
+        var result = success.LogOnError(_ => { });
+
+        await Assert.That(result.IsT0).IsTrue();
+        await Assert.That(result.AsT0.Path).IsEqualTo("/valid");
+    }
+
+    [Test("WithDiagnostics returns the inner result unchanged")]
+    public async Task WithDiagnosticsReturnsInnerResult()
+    {
+        var expectedError = new WriteResult.Error("disk full");
+        WriteTestOutput inner = _ => expectedError;
+        var decorated = inner.WithDiagnostics(_ => { });
+
+        var result = decorated(new TestRunOutput([], "passed"));
+
+        await Assert.That(result).IsEqualTo(expectedError);
+    }
+}

--- a/reporters/dotnet/TddGuard.Dotnet.Tests/ListenerFixture.cs
+++ b/reporters/dotnet/TddGuard.Dotnet.Tests/ListenerFixture.cs
@@ -1,0 +1,142 @@
+using System.Text.Json;
+using TddGuard.Dotnet.Core;
+
+namespace TddGuard.Dotnet.Tests;
+
+internal static class ListenerFixture
+{
+    internal static ArrangePhase Arrange(Func<Dotnet.TddGuardListener, Task> arrange)
+        => new(arrange);
+
+    internal static ArrangePhase Arrange()
+        => new(_ => Task.CompletedTask);
+
+    internal sealed class ArrangePhase(Func<Dotnet.TddGuardListener, Task> arrange)
+    {
+        internal ActPhase Act() => new(arrange);
+    }
+
+    internal sealed class ActPhase(Func<Dotnet.TddGuardListener, Task> arrange)
+    {
+        internal async Task Assert(Func<JsonElement, Task> assert)
+        {
+            var result = await Run();
+            try
+            {
+                var json = await File.ReadAllTextAsync(JsonPath(result.TempDir));
+                var root = JsonDocument.Parse(json).RootElement;
+                await assert(root);
+            }
+            finally
+            {
+                result.Cleanup();
+            }
+        }
+
+        internal async Task AssertNoOutput()
+        {
+            var result = await Run();
+            try
+            {
+                await global::TUnit.Assertions.Assert.That(File.Exists(JsonPath(result.TempDir))).IsFalse();
+            }
+            finally
+            {
+                result.Cleanup();
+            }
+        }
+
+        /// <summary>
+        /// Runs the full pipeline synchronously and returns the parsed JSON output,
+        /// or null when the session produced no output. Caller owns cleanup via Dispose.
+        /// Designed for property-based tests where FsCheck expects a synchronous bool.
+        /// </summary>
+        internal PipelineResult Execute()
+        {
+            var result = Run().GetAwaiter().GetResult();
+            var path = JsonPath(result.TempDir);
+
+            if (!File.Exists(path))
+                return new PipelineResult(null, result.TempDir);
+
+            var json = File.ReadAllText(path);
+            var root = JsonDocument.Parse(json).RootElement;
+            return new PipelineResult(root, result.TempDir);
+        }
+
+        private async Task<RunResult> Run()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            var listener = CreateListener(tempDir);
+
+            await listener.OnTestSessionStartingAsync(MtpStubs.StubSessionContext());
+            await arrange(listener);
+            await listener.OnTestSessionFinishingAsync(MtpStubs.StubSessionContext());
+
+            return new RunResult(tempDir);
+        }
+
+        private sealed record RunResult(string TempDir)
+        {
+            internal void Cleanup()
+            {
+                if (Directory.Exists(TempDir)) Directory.Delete(TempDir, true);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Result of a synchronous pipeline execution. Holds the parsed JSON (or null
+    /// for no output) and owns temp directory cleanup. Use with <c>using</c>.
+    /// </summary>
+    internal sealed class PipelineResult(JsonElement? output, string tempDir) : IDisposable
+    {
+        internal JsonElement? Output => output;
+        internal bool HasOutput => output.HasValue;
+
+        public void Dispose()
+        {
+            if (Directory.Exists(tempDir)) Directory.Delete(tempDir, true);
+        }
+    }
+
+    internal sealed record ListenerResult(
+        Dotnet.TddGuardListener Listener,
+        Func<string> ReadTestJson,
+        string TempDir);
+
+    internal static ListenerResult Create(
+        GetEnvironmentVariable? getEnv = null,
+        GetCurrentWorkingDirectory? getCwd = null)
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+        var listener = CreateListener(tempDir, getEnv, getCwd);
+
+        var jsonPath = Path.Combine(
+            tempDir, ".claude", "tdd-guard", "data", "test.json");
+
+        return new ListenerResult(
+            Listener: listener,
+            ReadTestJson: () => File.ReadAllText(jsonPath),
+            TempDir: tempDir);
+    }
+
+    internal static string JsonPath(string tempDir)
+        => Path.Combine(tempDir, ".claude", "tdd-guard", "data", "test.json");
+
+    internal static bool HasTestJson(string tempDir)
+        => File.Exists(JsonPath(tempDir));
+
+    private static Dotnet.TddGuardListener CreateListener(
+        string tempDir,
+        GetEnvironmentVariable? getEnv = null,
+        GetCurrentWorkingDirectory? getCwd = null)
+    {
+        var root = ProjectRootResolver.Resolve(
+            getEnv ?? (_ => tempDir),
+            getCwd ?? (() => tempDir)).AsT0; // Safe in test harness — always valid
+        var write = ReportFileWriter.Create(root.Path);
+        return new Dotnet.TddGuardListener(write);
+    }
+}

--- a/reporters/dotnet/TddGuard.Dotnet.Tests/MtpStubs.cs
+++ b/reporters/dotnet/TddGuard.Dotnet.Tests/MtpStubs.cs
@@ -1,0 +1,112 @@
+using FsCheck;
+using FsCheck.Fluent;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Services;
+
+namespace TddGuard.Dotnet.Tests;
+
+internal static class MtpStubs
+{
+    internal static StubTestSessionContext StubSessionContext()
+    {
+        return new StubTestSessionContext();
+    }
+
+    internal static StubDataProducer StubProducer()
+    {
+        return new StubDataProducer();
+    }
+
+    internal static TestNodeUpdateMessage MakeTestUpdate(
+        string name,
+        TestNodeStateProperty stateProperty,
+        string? filePath = "DefaultFile.cs")
+    {
+        var properties = filePath != null
+            ? new PropertyBag(stateProperty, new TestFileLocationProperty(filePath, new LinePositionSpan(new LinePosition(1, 0), new LinePosition(1, 0))))
+            : new PropertyBag(stateProperty);
+
+        var node = new TestNode
+        {
+            Uid = new TestNodeUid($"assembly/TestClass/{name}"),
+            DisplayName = name,
+            Properties = properties,
+        };
+
+        return new TestNodeUpdateMessage(default, node);
+    }
+
+    /// <summary>
+    /// Tagged wrapper pairing an MTP message with whether the event represents a failure,
+    /// so PBT properties can compute expected outcomes without inspecting MTP internals.
+    /// </summary>
+    internal sealed record TaggedEvent(TestNodeUpdateMessage Message, bool IsFailed);
+
+    internal static Gen<TaggedEvent> GenTaggedEvent()
+    {
+        var genName = Gen.OneOf(
+            ArbMap.Default.GeneratorFor<NonEmptyString>().Select(s => s.Get),
+            Gen.Constant("has \"quotes\""),
+            Gen.Constant("has\nnewlines"),
+            Gen.Constant("has\\backslashes"),
+            Gen.Constant("has\ttabs"),
+            Gen.Constant("unicode: \u00e9\u00f1\u00fc"));
+
+        var genPath = Gen.OneOf(
+            Gen.Constant<string?>("/src/A.cs"),
+            Gen.Constant<string?>("/src/B.cs"),
+            Gen.Constant<string?>("/tests/C.cs"),
+            Gen.Constant<string?>(@"C:\Src\D.cs"),
+            Gen.Constant<string?>(null));
+
+        var genPassed = from n in genName from p in genPath
+            select new TaggedEvent(MakeTestUpdate(n, new PassedTestNodeStateProperty(), p), false);
+
+        var genFailedWithException = from n in genName from p in genPath
+            select new TaggedEvent(
+                MakeTestUpdate(n, new FailedTestNodeStateProperty(
+                    new InvalidOperationException("generated failure"), "assertion"), p), true);
+
+        var genFailedWithExplanation = from n in genName from p in genPath
+            select new TaggedEvent(
+                MakeTestUpdate(n, new FailedTestNodeStateProperty("explanation only"), p), true);
+
+        var genFailedBare = from n in genName from p in genPath
+            select new TaggedEvent(
+                MakeTestUpdate(n, new FailedTestNodeStateProperty(), p), true);
+
+        var genSkipped = from n in genName from p in genPath
+            select new TaggedEvent(MakeTestUpdate(n, new SkippedTestNodeStateProperty(), p), false);
+
+        var genError = from n in genName from p in genPath
+            select new TaggedEvent(
+                MakeTestUpdate(n, new ErrorTestNodeStateProperty(
+                    new InvalidOperationException("error state"), "error"), p), true);
+
+        return Gen.OneOf(genPassed, genFailedWithException, genFailedWithExplanation,
+            genFailedBare, genSkipped, genError);
+    }
+
+    internal sealed class StubTestSessionContext : ITestSessionContext
+    {
+        public Microsoft.Testing.Platform.TestHost.SessionUid SessionUid => new("stub-session");
+        public CancellationToken CancellationToken => CancellationToken.None;
+    }
+
+    internal sealed class StubData(string displayName, string? description) : IData
+    {
+        public string DisplayName => displayName;
+        public string? Description => description;
+    }
+
+    internal sealed class StubDataProducer : IDataProducer
+    {
+        public string Uid => "stub";
+        public string Version => "1.0.0";
+        public string DisplayName => "Stub";
+        public string Description => "Stub producer";
+        public Type[] DataTypesProduced => [];
+        public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+    }
+
+}

--- a/reporters/dotnet/TddGuard.Dotnet.Tests/ProjectRootResolverTests.cs
+++ b/reporters/dotnet/TddGuard.Dotnet.Tests/ProjectRootResolverTests.cs
@@ -1,0 +1,149 @@
+using TddGuard.Dotnet.Core;
+
+namespace TddGuard.Dotnet.Tests;
+
+internal sealed class ProjectRootResolverTests
+{
+    [Test("prefers TDD_GUARD_PROJECT_ROOT env var")]
+    public async Task PrefersProjectRootEnvVar()
+    {
+        var root = "/custom/root";
+        GetEnvironmentVariable getEnv = name => name == "TDD_GUARD_PROJECT_ROOT" ? root : null;
+
+        var result = ProjectRootResolver.Resolve(getEnv, () => root);
+        await Assert.That(result.IsT0).IsTrue();
+        await Assert.That(result.AsT0.Path).IsEqualTo(Path.GetFullPath(root));
+    }
+
+    [Test("falls back to CLAUDE_PROJECT_DIR")]
+    public async Task FallsBackToClaudeProjectDir()
+    {
+        var dir = "/claude/dir";
+
+        var result = ProjectRootResolver.Resolve(
+            name => name == "CLAUDE_PROJECT_DIR" ? dir : null,
+            () => dir);
+        await Assert.That(result.IsT0).IsTrue();
+        await Assert.That(result.AsT0.Path).IsEqualTo(Path.GetFullPath(dir));
+    }
+
+    [Test("returns error when neither env var is set (ADR-010)")]
+    public async Task ReturnsErrorWhenNeitherEnvVarIsSet()
+    {
+        var result = ProjectRootResolver.Resolve(
+            _ => null,
+            () => "/fallback/cwd");
+        await Assert.That(result.IsT1).IsTrue();
+        await Assert.That(result.AsT1.Reason).Contains("TDD_GUARD_PROJECT_ROOT");
+    }
+
+    [Test("returns error when env var is empty string")]
+    public async Task ReturnsErrorWhenEnvVarIsEmptyString()
+    {
+        var result = ProjectRootResolver.Resolve(
+            name => name == "TDD_GUARD_PROJECT_ROOT" ? string.Empty : null,
+            () => "/some/dir");
+        await Assert.That(result.IsT1).IsTrue();
+    }
+
+    [Test("returns error when cwd is outside project root")]
+    public async Task ReturnsErrorWhenCwdIsOutsideProjectRoot()
+    {
+        var result = ProjectRootResolver.Resolve(
+            name => name == "TDD_GUARD_PROJECT_ROOT" ? "/project/root" : null,
+            () => "/somewhere/else");
+        await Assert.That(result.IsT1).IsTrue();
+    }
+
+    [Test("accepts cwd equal to root")]
+    public async Task AcceptsCwdEqualToRoot()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "test-root");
+
+        var result = ProjectRootResolver.Resolve(
+            name => name == "TDD_GUARD_PROJECT_ROOT" ? root : null,
+            () => root);
+        await Assert.That(result.IsT0).IsTrue();
+    }
+
+    [Test("accepts cwd as descendant of root")]
+    public async Task AcceptsCwdAsDescendantOfRoot()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "test-root");
+        var cwd = Path.Combine(root, "src", "tests");
+
+        var result = ProjectRootResolver.Resolve(
+            name => name == "TDD_GUARD_PROJECT_ROOT" ? root : null,
+            () => cwd);
+        await Assert.That(result.IsT0).IsTrue();
+    }
+
+    [Test("normalises parent segments in root path")]
+    public async Task NormalisesParentSegmentsInRootPath()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "test-root");
+        var rootWithDotDot = Path.Combine(root, "subdir", "..");
+
+        var result = ProjectRootResolver.Resolve(
+            name => name == "TDD_GUARD_PROJECT_ROOT" ? rootWithDotDot : null,
+            () => root);
+        await Assert.That(result.IsT0).IsTrue();
+        await Assert.That(result.AsT0.Path).IsEqualTo(Path.GetFullPath(root));
+    }
+
+    [Test("handles trailing separator on root path")]
+    public async Task HandlesTrailingSeparatorOnRootPath()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "test-root");
+        var rootWithTrailing = root + Path.DirectorySeparatorChar;
+
+        var result = ProjectRootResolver.Resolve(
+            name => name == "TDD_GUARD_PROJECT_ROOT" ? rootWithTrailing : null,
+            () => root);
+        await Assert.That(result.IsT0).IsTrue();
+    }
+
+    [Test("resolves symlinked root against real cwd path")]
+    public async Task ResolvesSymlinkedRootAgainstRealCwdPath()
+    {
+        // macOS: /var -> /private/var, so env var might have /var/... while cwd resolves to /private/var/...
+        var realDir = Path.Combine(Path.GetTempPath(), "tdd-guard-symlink-test");
+        var linkDir = Path.Combine(Path.GetTempPath(), "tdd-guard-symlink-link");
+        try
+        {
+            Directory.CreateDirectory(realDir);
+            if (Directory.Exists(linkDir)) Directory.Delete(linkDir);
+            Directory.CreateSymbolicLink(linkDir, realDir);
+
+            // Root is the symlink path, cwd is the real path
+            var result = ProjectRootResolver.Resolve(
+                name => name == "TDD_GUARD_PROJECT_ROOT" ? linkDir : null,
+                () => realDir);
+            await Assert.That(result.IsT0).IsTrue();
+        }
+        finally
+        {
+            if (Directory.Exists(linkDir)) Directory.Delete(linkDir);
+            if (Directory.Exists(realDir)) Directory.Delete(realDir, true);
+        }
+    }
+
+    [Test("TDD_GUARD_PROJECT_ROOT takes precedence over CLAUDE_PROJECT_DIR")]
+    public async Task ProjectRootTakesPrecedenceOverClaudeProjectDir()
+    {
+        var preferred = Path.Combine(Path.GetTempPath(), "preferred");
+        var fallback = Path.Combine(Path.GetTempPath(), "fallback");
+
+        var result = ProjectRootResolver.Resolve(
+            name => name switch
+            {
+                "TDD_GUARD_PROJECT_ROOT" => preferred,
+                "CLAUDE_PROJECT_DIR" => fallback,
+                _ => null
+            },
+            () => preferred);
+
+        await Assert.That(result.IsT0).IsTrue();
+        await Assert.That(result.AsT0.Path).IsEqualTo(Path.GetFullPath(preferred));
+    }
+}

--- a/reporters/dotnet/TddGuard.Dotnet.Tests/README.md
+++ b/reporters/dotnet/TddGuard.Dotnet.Tests/README.md
@@ -1,0 +1,216 @@
+# TddGuard.Dotnet.Tests
+
+## Testing philosophy
+
+Tests verify **behaviour, not implementation**. The system under test (SUT) is
+`TddGuardListener` exercised through its MTP interface — events go in, JSON
+comes out. Tests never reference internal types like `CollectedResult`,
+`TestRunSummariser`, or `TestReportSerializer` directly.
+
+This means we can refactor internals freely without breaking tests, and every
+test failure points to a genuine change in observable behaviour.
+
+## Test layers
+
+### Unit tests (`TddGuardListenerTests`)
+
+Example-based tests that verify specific, named behaviours: "writes 'passed'
+reason for passing test", "ignores in-progress nodes", etc. Each test follows
+strict **Arrange/Act/Assert** via the `ListenerFixture` DSL:
+
+```csharp
+await ListenerFixture
+    .Arrange(async listener =>
+    {
+        await listener.ConsumeAsync(StubProducer(), An.Event().Named("test1").Passed(), default);
+    })
+    .Act()
+    .Assert(async root =>
+    {
+        await Assert.That(root.Reason()).IsEqualTo("passed");
+    });
+```
+
+- **Arrange** feeds MTP events to the listener
+- **Act** triggers `OnTestSessionFinishingAsync` (the write)
+- **Assert** inspects the resulting JSON
+
+These tests are fast, deterministic, and produce pinpoint failure messages.
+
+### Property-based tests (`TddGuardListenerPropertyTests`)
+
+FsCheck-driven tests that verify universal properties across hundreds of
+randomly generated event sequences: "count is preserved", "reason reflects
+failures", "output is valid JSON", etc.
+
+Properties use `ListenerFixture.Execute()` which returns a synchronous
+`PipelineResult` suitable for FsCheck's `Prop.ForAll`:
+
+```csharp
+Prop.ForAll(Arb.From(genEvents), events =>
+{
+    using var result = RunEvents(events);
+    return result.Output!.Value.GetProperty("reason").GetString() == expected;
+});
+```
+
+These tests explore the input space far more broadly than hand-crafted examples
+and catch edge cases a person would never consider.
+
+### Supporting test files
+
+| File                       | Purpose                                                            |
+| -------------------------- | ------------------------------------------------------------------ |
+| `ProjectRootResolverTests` | Unit tests for env var resolution (pure function, tested directly) |
+| `ReportFileWriterTests`    | Unit tests for file I/O (temp dir, error paths, overwrite)         |
+| `DiagnosticDecoratorTests` | Unit tests for logging decorators (spy-based)                      |
+| `TestReportWriterTests`    | Unit tests for the write-or-skip orchestrator                      |
+| `TestNodeMapperTests`      | Unit tests for UID parsing (pure function)                         |
+| `TddGuardBuilderTests`     | Unit tests for the MTP registration composition root               |
+
+These test lower-level components directly because their contracts are stable
+public APIs (file paths, env vars, JSON output). They don't test internal
+wiring — that's covered by the outside-in listener tests and PBTs.
+
+## Test infrastructure
+
+### `ListenerFixture`
+
+The test harness that manages the listener lifecycle. Provides three APIs:
+
+- **`Arrange(...).Act().Assert(...)`** — async DSL for unit tests
+- **`Arrange(...).Act().AssertNoOutput()`** — for tests expecting no JSON output
+- **`Arrange(...).Act().Execute()`** — synchronous pipeline for PBTs, returns `PipelineResult`
+- **`Create()`** — manual session control for tests that need multiple sessions or concurrency
+
+### `TestEventBuilder` (`An.Event()`)
+
+Test Data Builder for MTP events. Hides MTP-specific types behind
+intent-revealing methods:
+
+```csharp
+An.Event().Named("test1").InFile("/src/A.cs").Passed()
+An.Event().Named("test1").Failed("assertion message")
+An.Event().Named("test1").FailedWithExplanation("no exception, just text")
+An.Event().Named("test1").FailedBare()       // no exception, no explanation
+An.Event().Named("test1").Error("setup failed")
+An.Event().Named("test1").Skipped()
+An.Event().Named("test1").InProgress()
+An.Event().Named("test1").Discovered()
+An.Event().Named("test1").WithNoFilePath().Passed()  // null file path
+```
+
+### `MtpStubs`
+
+Low-level MTP stubs and the FsCheck generator (`GenTaggedEvent`). The generator
+produces `TaggedEvent` records that pair an MTP message with a `bool IsFailed`
+flag, so PBT properties can compute expected outcomes without inspecting MTP
+internals.
+
+### `TestJsonAssert`
+
+Extension methods for navigating `JsonElement` in assertions: `root.Reason()`,
+`root.Module().Test().State()`, `root.Module().Test().ErrorMessage()`, etc.
+
+### `TempDir`
+
+Disposable temp directory helper for file I/O tests.
+
+## Framework compatibility smoke tests
+
+The `TddGuard.Dotnet.Compat.*` projects sit alongside the test project
+and prove the MTP extension works with every major .NET test framework.
+Each is a standalone runnable test project with a single passing test.
+
+| Project         | Framework | Notes                                                       |
+| --------------- | --------- | ----------------------------------------------------------- |
+| `Compat.TUnit`  | TUnit 0.x | Native MTP, file path as module ID                          |
+| `Compat.MSTest` | MSTest v4 | Native MTP, file path as module ID                          |
+| `Compat.XUnit`  | xUnit v3  | Native MTP via `xunit.v3.mtp-v2`, file path as module ID    |
+| `Compat.XUnit2` | xUnit v2  | Third-party adapter (`YTest.MTP.XUnit2`), hash as module ID |
+| `Compat.NUnit`  | NUnit 4   | MTP via NUnit runner, UID as module ID (no file path)       |
+
+### How they work
+
+Each project has three files:
+
+- **`.csproj`** targets net10.0, references the framework package and
+  `TddGuard.Dotnet` via ProjectReference. A `<TestingPlatformBuilderHook>`
+  MSBuild item tells MTP's codegen where to find the hook class.
+- **`TestingPlatformBuilderHook.cs`** is the MTP entry point. MTP's
+  source generator calls `AddExtensions` at startup, which delegates to
+  `TddGuardBuilder.Register(builder)` to wire up the listener.
+- **`SmokeTests.cs`** has one passing test in the framework's native syntax.
+
+When `dotnet test` runs, MTP starts the test host, calls the hook,
+registers our listener, the framework discovers and runs the test,
+MTP publishes `TestNodeUpdateMessage` events, our listener collects
+them, and `OnTestSessionFinishingAsync` writes `test.json`.
+
+The extension never knows which framework is running. It subscribes to
+`TestNodeUpdateMessage` which is a generic MTP event type. The only
+observable differences between frameworks are in module ID source
+(file path vs UID fallback) and UID format, both handled by existing
+null-checks in `TestNodeMapper`.
+
+### Why ProjectReference instead of NuGet
+
+The compat projects reference `TddGuard.Dotnet` via ProjectReference
+(local source) rather than PackageReference (NuGet). This avoids the
+NuGet pack/restore cycle and firewall issues with CDN IPs. The manual
+`<TestingPlatformBuilderHook>` MSBuild item replaces what the NuGet
+package's `buildTransitive` props would normally inject. The integration
+tests (`reporters/test/factories/dotnet.ts`) separately test the NuGet
+packaging path.
+
+### Running the smoke tests
+
+```bash
+export TDD_GUARD_PROJECT_ROOT=/workspace
+cd /workspace/reporters/dotnet/TddGuard.Dotnet.Compat.MSTest
+dotnet test
+cat /workspace/.claude/tdd-guard/data/test.json
+```
+
+Repeat for each `Compat.*` project. If `test.json` appears with
+`"reason":"passed"`, the framework works.
+
+## Why outside-in
+
+Tests are written from the perspective of the consumer, not the
+implementer. The SUT (system under test) is the `TddGuardListener`
+exercised through its MTP interface: feed it events, trigger the
+session finish, read the JSON.
+
+This matters because:
+
+- **Refactoring is free.** You can restructure `Summarise`, change how
+  `Serialize` works, rename internal types, or merge classes — and no
+  test breaks as long as the JSON output stays the same.
+- **Tests document behaviour.** Each test says what the system does
+  ("writes 'passed' reason for passing test"), not how it does it.
+  New contributors read the tests to understand the contract.
+- **Agents continue the pattern.** If you are an AI agent adding tests:
+  use `ListenerFixture`, use `An.Event()` to build inputs, assert on
+  the JSON output. Do not reference `CollectedResult`, `TestRunOutput`,
+  `Summarise`, or `Serialize` in test assertions. Those are internals.
+
+The supporting tests (`ProjectRootResolverTests`, `ReportFileWriterTests`,
+etc.) test lower-level components directly because their contracts are
+stable public boundaries (env vars, file paths, JSON structure). They
+follow the same principle: test through the public API, not the internals.
+
+## Running tests
+
+All commands run inside the devcontainer:
+
+```bash
+docker exec -w /workspace/reporters/dotnet <container> dotnet test --project TddGuard.Dotnet.Tests
+```
+
+For coverage:
+
+```bash
+docker exec -w /workspace/reporters/dotnet <container> dotnet test --project TddGuard.Dotnet.Tests \
+  -- --coverage --coverage-output-format cobertura --coverage-output /tmp/coverage.xml
+```

--- a/reporters/dotnet/TddGuard.Dotnet.Tests/ReportFileWriterTests.cs
+++ b/reporters/dotnet/TddGuard.Dotnet.Tests/ReportFileWriterTests.cs
@@ -1,0 +1,83 @@
+using TddGuard.Dotnet.Core;
+
+namespace TddGuard.Dotnet.Tests;
+
+internal sealed class ReportFileWriterTests
+{
+    [Test("writes JSON to .claude/tdd-guard/data/")]
+    public async Task WritesJsonToDataDirectory()
+    {
+        await TempDir.Run(async tempDir =>
+        {
+            var write = ReportFileWriter.Create(tempDir);
+            var result = write(MakePassingOutput());
+
+            await Assert.That(result is WriteResult.Success).IsTrue();
+
+            var expectedPath = Path.Combine(tempDir, ".claude", "tdd-guard", "data", "test.json");
+            await Assert.That(File.Exists(expectedPath)).IsTrue();
+
+            var json = await File.ReadAllTextAsync(expectedPath);
+            await Assert.That(json).Contains("\"testModules\"");
+        });
+    }
+
+    [Test("returns error for invalid path")]
+    public async Task ReturnsErrorForInvalidPath()
+    {
+        var write = ReportFileWriter.Create("/dev/null/impossible/path");
+        var result = write(MakePassingOutput());
+
+        await Assert.That(result is WriteResult.Error).IsTrue();
+        await Assert.That(((WriteResult.Error)result).Message).Contains("impossible");
+    }
+
+    [Test("creates intermediate directories when they do not exist")]
+    public async Task CreatesIntermediateDirectories()
+    {
+        await TempDir.Run(async tempDir =>
+        {
+            await Assert.That(Directory.Exists(tempDir)).IsFalse();
+
+            var write = ReportFileWriter.Create(tempDir);
+            var result = write(MakePassingOutput());
+
+            await Assert.That(result is WriteResult.Success).IsTrue();
+            var expectedPath = Path.Combine(tempDir, ".claude", "tdd-guard", "data", "test.json");
+            await Assert.That(File.Exists(expectedPath)).IsTrue();
+        });
+    }
+
+    [Test("overwrites existing test.json with new content")]
+    public async Task OverwritesExistingTestJson()
+    {
+        await TempDir.Run(async tempDir =>
+        {
+            var write = ReportFileWriter.Create(tempDir);
+
+            var firstOutput = MakeOutputWithReason("passed");
+            var firstResult = write(firstOutput);
+            await Assert.That(firstResult is WriteResult.Success).IsTrue();
+
+            var secondOutput = MakeOutputWithReason("failed");
+            var secondResult = write(secondOutput);
+            await Assert.That(secondResult is WriteResult.Success).IsTrue();
+
+            var expectedPath = Path.Combine(tempDir, ".claude", "tdd-guard", "data", "test.json");
+            var json = await File.ReadAllTextAsync(expectedPath);
+            await Assert.That(json).Contains("\"failed\"");
+            await Assert.That(json).DoesNotContain("\"passed\"");
+        });
+    }
+
+    private static TestRunOutput MakePassingOutput()
+        => MakeOutputWithReason("passed");
+
+    private static TestRunOutput MakeOutputWithReason(string reason)
+    {
+        var state = reason == "failed" ? "failed" : "passed";
+        var entry = new TestEntryOutput("test1", "Module/test1", state, null);
+        var module = new TestModuleOutput("Module", [entry]);
+        return new TestRunOutput([module], reason);
+    }
+}

--- a/reporters/dotnet/TddGuard.Dotnet.Tests/TddGuard.Dotnet.Tests.csproj
+++ b/reporters/dotnet/TddGuard.Dotnet.Tests/TddGuard.Dotnet.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <OutputType>Exe</OutputType>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FsCheck" Version="3.*" />
+    <PackageReference Include="TUnit" Version="0.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../TddGuard.Dotnet/TddGuard.Dotnet.csproj" />
+  </ItemGroup>
+
+  <!-- Register TDD Guard extension hook with MTP's SelfRegisteredExtensions codegen -->
+  <ItemGroup>
+    <TestingPlatformBuilderHook Include="TddGuard.Dotnet">
+      <DisplayName>TddGuard.Dotnet</DisplayName>
+      <TypeFullName>TestingPlatformBuilderHook</TypeFullName>
+    </TestingPlatformBuilderHook>
+  </ItemGroup>
+
+</Project>

--- a/reporters/dotnet/TddGuard.Dotnet.Tests/TddGuardBuilderTests.cs
+++ b/reporters/dotnet/TddGuard.Dotnet.Tests/TddGuardBuilderTests.cs
@@ -1,0 +1,166 @@
+using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Platform.CommandLine;
+using Microsoft.Testing.Platform.Configurations;
+using Microsoft.Testing.Platform.Extensions;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+using Microsoft.Testing.Platform.Extensions.TestHost;
+using Microsoft.Testing.Platform.Logging;
+using Microsoft.Testing.Platform.TestHost;
+using Microsoft.Testing.Platform.TestHostControllers;
+
+namespace TddGuard.Dotnet.Tests;
+
+internal sealed class TddGuardBuilderTests
+{
+    [Test("registers listener when project root resolves")]
+    public async Task RegistersListenerWhenProjectRootResolves()
+    {
+        var spy = new SpyTestHostManager();
+        var builder = new StubBuilder(spy);
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+        TddGuardBuilder.Register(
+            builder,
+            getEnv: _ => tempDir,
+            getCwd: () => tempDir);
+
+        await Assert.That(spy.LifetimeHandleCount).IsEqualTo(1);
+        await Assert.That(spy.DataConsumerCount).IsEqualTo(1);
+    }
+
+    [Test("skips registration when resolver returns error")]
+    public async Task SkipsRegistrationWhenResolverReturnsError()
+    {
+        var spy = new SpyTestHostManager();
+        var builder = new StubBuilder(spy);
+
+        TddGuardBuilder.Register(
+            builder,
+            getEnv: _ => null,
+            getCwd: () => "/some/dir");
+
+        await Assert.That(spy.LifetimeHandleCount).IsEqualTo(0);
+        await Assert.That(spy.DataConsumerCount).IsEqualTo(0);
+    }
+
+    [Test("logs diagnostic when resolver returns error")]
+    public async Task LogsDiagnosticWhenResolverReturnsError()
+    {
+        string? captured = null;
+        var builder = new StubBuilder(new SpyTestHostManager());
+
+        TddGuardBuilder.Register(
+            builder,
+            getEnv: _ => null,
+            getCwd: () => "/some/dir",
+            log: msg => captured = msg);
+
+        await Assert.That(captured).IsNotNull();
+        await Assert.That(captured!).Contains("disabled");
+    }
+
+    // Coverage: exercises the null-coalescing default branches for getEnv/getCwd/log
+    // parameters. Outcome depends on whether TDD_GUARD_PROJECT_ROOT is set in the
+    // environment, so we assert "doesn't throw" rather than a specific registration state.
+    [Test("uses default delegates when none provided")]
+    public async Task UsesDefaultDelegatesWhenNoneProvided()
+    {
+        var spy = new SpyTestHostManager();
+        var builder = new StubBuilder(spy);
+
+        TddGuardBuilder.Register(builder);
+
+        await Assert.That(spy.LifetimeHandleCount is 0 or 1).IsTrue();
+        await Assert.That(spy.DataConsumerCount is 0 or 1).IsTrue();
+    }
+
+    [Test("throws ArgumentNullException for null builder")]
+    public async Task ThrowsArgumentNullExceptionForNullBuilder()
+    {
+        await Assert.That(() => TddGuardBuilder.Register(null!))
+            .ThrowsExactly<ArgumentNullException>();
+    }
+
+    // The shipped TestingPlatformBuilderHook is the entry point MTP calls
+    // at runtime. These tests verify it delegates to Register correctly and
+    // that its contract matches the buildTransitive MSBuild props.
+    [Test("shipped TestingPlatformBuilderHook delegates to Register")]
+    public async Task ShippedHookDelegatesToRegister()
+    {
+        var spy = new SpyTestHostManager();
+        var builder = new StubBuilder(spy);
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+        Dotnet.TestingPlatformBuilderHook.AddExtensions(builder,
+            [
+                $"--internal-tdd-guard-project-root={tempDir}",
+                $"--internal-tdd-guard-cwd={tempDir}"
+            ]);
+
+        // The hook calls Register which calls Resolve. Without env vars,
+        // it'll take the error path and skip registration. We can't control
+        // the env from here, so verify it ran without throwing.
+        await Assert.That(spy.LifetimeHandleCount is 0 or 1).IsTrue();
+    }
+
+    [Test("shipped hook type matches buildTransitive props TypeFullName")]
+    public async Task ShippedHookTypeMatchesBuildTransitiveProps()
+    {
+        // The buildTransitive props declare TypeFullName as
+        // "TddGuard.Dotnet.TestingPlatformBuilderHook". If someone renames
+        // the class without updating the props, MTP won't find the hook.
+        var hookType = typeof(Dotnet.TestingPlatformBuilderHook);
+
+        await Assert.That(hookType.FullName).IsEqualTo("TddGuard.Dotnet.TestingPlatformBuilderHook");
+        await Assert.That(hookType.IsPublic).IsTrue();
+        await Assert.That(hookType.IsAbstract && hookType.IsSealed).IsTrue(); // static class
+
+        var method = hookType.GetMethod("AddExtensions");
+        await Assert.That(method).IsNotNull();
+        await Assert.That(method!.IsPublic).IsTrue();
+        await Assert.That(method.IsStatic).IsTrue();
+        await Assert.That(method.GetParameters()).HasCount().EqualTo(2);
+    }
+
+    private sealed class SpyTestHostManager : ITestHostManager
+    {
+        internal int LifetimeHandleCount { get; private set; }
+        internal int DataConsumerCount { get; private set; }
+
+        public void AddDataConsumer(Func<IServiceProvider, IDataConsumer> dataConsumerFactory)
+            => DataConsumerCount++;
+
+        public void AddDataConsumer<T>(CompositeExtensionFactory<T> compositeServiceFactory)
+            where T : class, IDataConsumer
+            => DataConsumerCount++;
+
+        public void AddTestSessionLifetimeHandle(Func<IServiceProvider, ITestSessionLifetimeHandler> testSessionLifetimeHandleFactory)
+            => LifetimeHandleCount++;
+
+        public void AddTestSessionLifetimeHandle<T>(CompositeExtensionFactory<T> compositeServiceFactory)
+            where T : class, ITestSessionLifetimeHandler
+            => LifetimeHandleCount++;
+
+        public void AddTestHostApplicationLifetime(Func<IServiceProvider, ITestHostApplicationLifetime> testHostApplicationLifetimeFactory)
+            => throw new NotImplementedException();
+    }
+
+    private sealed class StubBuilder(ITestHostManager testHost) : ITestApplicationBuilder
+    {
+        public ITestHostManager TestHost => testHost;
+        public ITestHostControllersManager TestHostControllers => throw new NotImplementedException();
+        public ICommandLineManager CommandLine => throw new NotImplementedException();
+#pragma warning disable TPEXP // Experimental API required by ITestApplicationBuilder
+        public IConfigurationManager Configuration => throw new NotImplementedException();
+        public ILoggingManager Logging => throw new NotImplementedException();
+#pragma warning restore TPEXP
+
+        public ITestApplicationBuilder RegisterTestFramework(
+            Func<IServiceProvider, ITestFrameworkCapabilities> capabilitiesFactory,
+            Func<ITestFrameworkCapabilities, IServiceProvider, ITestFramework> frameworkFactory)
+            => throw new NotImplementedException();
+
+        public Task<ITestApplication> BuildAsync() => throw new NotImplementedException();
+    }
+}

--- a/reporters/dotnet/TddGuard.Dotnet.Tests/TddGuardListenerPropertyTests.cs
+++ b/reporters/dotnet/TddGuard.Dotnet.Tests/TddGuardListenerPropertyTests.cs
@@ -1,0 +1,256 @@
+using System.Text.Json;
+using FsCheck;
+using FsCheck.Fluent;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using static TddGuard.Dotnet.Tests.MtpStubs;
+
+namespace TddGuard.Dotnet.Tests;
+
+internal sealed class TddGuardListenerPropertyTests
+{
+    private static ListenerFixture.PipelineResult RunEvents(IReadOnlyList<TaggedEvent> events)
+    {
+        return ListenerFixture
+            .Arrange(async listener =>
+            {
+                foreach (var evt in events)
+                    await listener.ConsumeAsync(StubProducer(), evt.Message, default);
+            })
+            .Act()
+            .Execute();
+    }
+
+    [Test("every consumed terminal event produces exactly one test entry in the output")]
+    public void CountPreservation()
+    {
+        var genEvents = Gen.NonEmptyListOf(GenTaggedEvent());
+
+        Prop.ForAll(Arb.From(genEvents), events =>
+        {
+            using var result = RunEvents(events);
+
+            var totalTests = result.Output!.Value
+                .GetProperty("testModules").EnumerateArray()
+                .Sum(m => m.GetProperty("tests").GetArrayLength());
+            return totalTests == events.Count;
+        }).QuickCheckThrowOnFailure();
+    }
+
+    [Test("reason is 'failed' iff any consumed event was a failure")]
+    public void ReasonReflectsFailures()
+    {
+        var genEvents = Gen.NonEmptyListOf(GenTaggedEvent());
+
+        Prop.ForAll(Arb.From(genEvents), events =>
+        {
+            var anyFailed = events.Any(e => e.IsFailed);
+
+            using var result = RunEvents(events);
+
+            var reason = result.Output!.Value.GetProperty("reason").GetString();
+            return reason == (anyFailed ? "failed" : "passed");
+        }).QuickCheckThrowOnFailure();
+    }
+
+    [Test("output has one module per distinct file path in the input")]
+    public void ModuleGroupingMatchesFilePaths()
+    {
+        var genEvents = Gen.NonEmptyListOf(GenTaggedEvent());
+
+        Prop.ForAll(Arb.From(genEvents), events =>
+        {
+            // Compute expected module count from the tagged events.
+            // Null file paths fall back to UID as module ID — each is unique per event.
+            var expectedModules = events
+                .Select((e, i) =>
+                {
+                    var node = e.Message.TestNode;
+                    var filePath = node.Properties.SingleOrDefault<TestFileLocationProperty>()?.FilePath;
+                    return filePath ?? node.Uid.Value;
+                })
+                .Distinct()
+                .Count();
+
+            using var result = RunEvents(events);
+
+            var moduleCount = result.Output!.Value.GetProperty("testModules").GetArrayLength();
+            return moduleCount == expectedModules;
+        }).QuickCheckThrowOnFailure();
+    }
+
+    [Test("every state string in the output is one of passed, failed, skipped")]
+    public void AllStateStringsAreValid()
+    {
+        var validStates = new HashSet<string> { "passed", "failed", "skipped" };
+        var genEvents = Gen.NonEmptyListOf(GenTaggedEvent());
+
+        Prop.ForAll(Arb.From(genEvents), events =>
+        {
+            using var result = RunEvents(events);
+
+            return result.Output!.Value
+                .GetProperty("testModules").EnumerateArray()
+                .SelectMany(m => m.GetProperty("tests").EnumerateArray())
+                .All(t => validStates.Contains(t.GetProperty("state").GetString()!));
+        }).QuickCheckThrowOnFailure();
+    }
+
+    [Test("output JSON conforms to the TDD Guard wire-format schema")]
+    public void JsonSchemaIsValid()
+    {
+        var genEvents = Gen.NonEmptyListOf(GenTaggedEvent());
+
+        Prop.ForAll(Arb.From(genEvents), events =>
+        {
+            using var result = RunEvents(events);
+
+            var root = result.Output!.Value;
+            if (root.GetProperty("reason").ValueKind != JsonValueKind.String) return false;
+            if (root.GetProperty("testModules").ValueKind != JsonValueKind.Array) return false;
+
+            foreach (var module in root.GetProperty("testModules").EnumerateArray())
+            {
+                if (module.GetProperty("moduleId").ValueKind != JsonValueKind.String) return false;
+                if (module.GetProperty("tests").ValueKind != JsonValueKind.Array) return false;
+
+                foreach (var test in module.GetProperty("tests").EnumerateArray())
+                {
+                    if (test.GetProperty("name").ValueKind != JsonValueKind.String) return false;
+                    if (test.GetProperty("fullName").ValueKind != JsonValueKind.String) return false;
+                    if (test.GetProperty("state").ValueKind != JsonValueKind.String) return false;
+                    if (test.TryGetProperty("errors", out var errors))
+                    {
+                        if (errors.ValueKind != JsonValueKind.Array) return false;
+                        foreach (var err in errors.EnumerateArray())
+                            if (err.GetProperty("message").ValueKind != JsonValueKind.String) return false;
+                    }
+                }
+            }
+
+            return true;
+        }).QuickCheckThrowOnFailure();
+    }
+
+    [Test("passing and skipped tests do not have an errors property in the JSON")]
+    public void NullErrorsOmitted()
+    {
+        var genEvents = Gen.NonEmptyListOf(GenTaggedEvent());
+
+        Prop.ForAll(Arb.From(genEvents), events =>
+        {
+            using var result = RunEvents(events);
+
+            return result.Output!.Value
+                .GetProperty("testModules").EnumerateArray()
+                .SelectMany(m => m.GetProperty("tests").EnumerateArray())
+                .Where(t => t.GetProperty("state").GetString() is "passed" or "skipped")
+                .All(t => !t.TryGetProperty("errors", out _));
+        }).QuickCheckThrowOnFailure();
+    }
+
+    [Test("error messages from failed events appear in the corresponding test entry")]
+    public void ErrorMessagesPreserved()
+    {
+        // Use only events with file paths so module grouping is predictable
+        var genPath = Gen.Elements("/src/Single.cs");
+        var genName = ArbMap.Default.GeneratorFor<NonEmptyString>().Select(s => s.Get);
+        var genFailedWithMessage = from n in genName from p in genPath
+            select new TaggedEvent(
+                MakeTestUpdate(n, new FailedTestNodeStateProperty(
+                    new InvalidOperationException("expected failure message"), "assertion"), p), true);
+        var genEvents = Gen.NonEmptyListOf(genFailedWithMessage);
+
+        Prop.ForAll(Arb.From(genEvents), events =>
+        {
+            using var result = RunEvents(events);
+
+            return result.Output!.Value
+                .GetProperty("testModules").EnumerateArray()
+                .SelectMany(m => m.GetProperty("tests").EnumerateArray())
+                .Where(t => t.GetProperty("state").GetString() == "failed")
+                .All(t => t.TryGetProperty("errors", out var errors)
+                    && errors.EnumerateArray().Any(e =>
+                        e.GetProperty("message").GetString()!.Contains("expected failure message", StringComparison.Ordinal)));
+        }).QuickCheckThrowOnFailure();
+    }
+
+    [Test("appending a failure to an all-passing sequence flips reason to 'failed'")]
+    public void AddingFailureFlipsReason()
+    {
+        var genPassedEvent = from n in ArbMap.Default.GeneratorFor<NonEmptyString>().Select(s => s.Get)
+                             from p in Gen.Elements("/src/A.cs", "/src/B.cs")
+                             select new TaggedEvent(MakeTestUpdate(n, new PassedTestNodeStateProperty(), p), false);
+        var genPassedEvents = Gen.NonEmptyListOf(genPassedEvent);
+
+        Prop.ForAll(Arb.From(genPassedEvents), passingEvents =>
+        {
+            // Baseline: all passing → reason "passed"
+            using var baseline = ListenerFixture
+                .Arrange(async listener =>
+                {
+                    foreach (var evt in passingEvents)
+                        await listener.ConsumeAsync(StubProducer(), evt.Message, default);
+                })
+                .Act()
+                .Execute();
+
+            var baseReason = baseline.Output!.Value.GetProperty("reason").GetString();
+            if (baseReason != "passed") return false;
+
+            // Append one failure → reason "failed"
+            var failedEvent = An.Event().Named("injected_failure").InFile("/src/A.cs").Failed("boom");
+
+            using var withFailure = ListenerFixture
+                .Arrange(async listener =>
+                {
+                    foreach (var evt in passingEvents)
+                        await listener.ConsumeAsync(StubProducer(), evt.Message, default);
+                    await listener.ConsumeAsync(StubProducer(), failedEvent, default);
+                })
+                .Act()
+                .Execute();
+
+            return withFailure.Output!.Value.GetProperty("reason").GetString() == "failed";
+        }).QuickCheckThrowOnFailure();
+    }
+
+    [Test("the same event sequence always produces identical JSON output")]
+    public void Determinism()
+    {
+        var genEvents = Gen.NonEmptyListOf(GenTaggedEvent());
+
+        Prop.ForAll(Arb.From(genEvents), events =>
+        {
+            using var first = RunEvents(events);
+            using var second = RunEvents(events);
+
+            return first.Output!.Value.GetRawText() == second.Output!.Value.GetRawText();
+        }).QuickCheckThrowOnFailure();
+    }
+
+    [Test("output JSON survives a deserialize-reserialize roundtrip")]
+    public void JsonRoundtrip()
+    {
+        var roundtripOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+            WriteIndented = false,
+        };
+        var genEvents = Gen.NonEmptyListOf(GenTaggedEvent());
+
+        Prop.ForAll(Arb.From(genEvents), events =>
+        {
+            using var result = RunEvents(events);
+
+            var originalJson = result.Output!.Value.GetRawText();
+            var deserialized = JsonSerializer.Deserialize<JsonElement>(originalJson);
+            var reserialized = JsonSerializer.Serialize(deserialized, roundtripOptions);
+
+            // Normalize both through JsonElement to compare structurally
+            var original = JsonSerializer.Deserialize<JsonElement>(originalJson);
+            var roundtripped = JsonSerializer.Deserialize<JsonElement>(reserialized);
+            return original.GetRawText() == roundtripped.GetRawText();
+        }).QuickCheckThrowOnFailure();
+    }
+}

--- a/reporters/dotnet/TddGuard.Dotnet.Tests/TddGuardListenerTests.cs
+++ b/reporters/dotnet/TddGuard.Dotnet.Tests/TddGuardListenerTests.cs
@@ -1,0 +1,437 @@
+using Microsoft.Testing.Platform.Extensions.Messages;
+using static TddGuard.Dotnet.Tests.MtpStubs;
+
+namespace TddGuard.Dotnet.Tests;
+
+internal sealed class TddGuardListenerTests
+{
+    [Test("writes 'passed' reason for passing test")]
+    public async Task WritesPassedReasonForPassingTest()
+    {
+        await ListenerFixture
+            .Arrange(async listener =>
+            {
+                await listener.ConsumeAsync(StubProducer(), An.Event().Named("test1").Passed(), default);
+            })
+            .Act()
+            .Assert(async root =>
+            {
+                await Assert.That(root.Reason()).IsEqualTo("passed");
+            });
+    }
+
+    [Test("writes 'failed' reason when any test fails")]
+    public async Task WritesFailedReasonWhenAnyTestFails()
+    {
+        await ListenerFixture
+            .Arrange(async listener =>
+            {
+                await listener.ConsumeAsync(StubProducer(), An.Event().Named("test1").Passed(), default);
+                await listener.ConsumeAsync(StubProducer(), An.Event().Named("test2").Failed("boom"), default);
+            })
+            .Act()
+            .Assert(async root =>
+            {
+                await Assert.That(root.Reason()).IsEqualTo("failed");
+            });
+    }
+
+    [Test("skipped tests count as passed for reason")]
+    public async Task SkippedTestsCountAsPassedForReason()
+    {
+        await ListenerFixture
+            .Arrange(async listener =>
+            {
+                await listener.ConsumeAsync(StubProducer(), An.Event().Named("test1").Skipped(), default);
+            })
+            .Act()
+            .Assert(async root =>
+            {
+                await Assert.That(root.Reason()).IsEqualTo("passed");
+                await Assert.That(root.Module().Test().State()).IsEqualTo("skipped");
+            });
+    }
+
+    [Test("does not write when no tests run")]
+    public async Task DoesNotWriteWhenNoTestsRun()
+    {
+        await ListenerFixture
+            .Arrange()
+            .Act()
+            .AssertNoOutput();
+    }
+
+    [Test("includes error message from exception")]
+    public async Task IncludesErrorMessageFromException()
+    {
+        await ListenerFixture
+            .Arrange(async listener =>
+            {
+                await listener.ConsumeAsync(StubProducer(), An.Event().Named("test1").Failed("Expected 6 but got 5"), default);
+            })
+            .Act()
+            .Assert(async root =>
+            {
+                var test = root.Module().Test();
+                await Assert.That(test.State()).IsEqualTo("failed");
+                await Assert.That(test.ErrorMessage()).Contains("Expected 6 but got 5");
+            });
+    }
+
+    [Test("uses explanation when no exception")]
+    public async Task UsesExplanationWhenNoException()
+    {
+        await ListenerFixture
+            .Arrange(async listener =>
+            {
+                await listener.ConsumeAsync(StubProducer(), An.Event().Named("test1").FailedWithExplanation("assertion failed"), default);
+            })
+            .Act()
+            .Assert(async root =>
+            {
+                await Assert.That(root.Module().Test().ErrorMessage()).IsEqualTo("assertion failed");
+            });
+    }
+
+    [Test("passed test has no errors in JSON")]
+    public async Task PassedTestHasNoErrorsInJson()
+    {
+        await ListenerFixture
+            .Arrange(async listener =>
+            {
+                await listener.ConsumeAsync(StubProducer(), An.Event().Named("test1").Passed(), default);
+            })
+            .Act()
+            .Assert(async root =>
+            {
+                await Assert.That(root.Module().Test().HasErrors()).IsFalse();
+            });
+    }
+
+    [Test("uses file path as module ID")]
+    public async Task UsesFilePathAsModuleId()
+    {
+        await ListenerFixture
+            .Arrange(async listener =>
+            {
+                await listener.ConsumeAsync(StubProducer(), An.Event().Named("test1").InFile("/src/Tests.cs").Passed(), default);
+            })
+            .Act()
+            .Assert(async root =>
+            {
+                await Assert.That(root.Module().ModuleId()).IsEqualTo("/src/Tests.cs");
+            });
+    }
+
+    [Test("falls back to UID as module ID")]
+    public async Task FallsBackToUidAsModuleId()
+    {
+        await ListenerFixture
+            .Arrange(async listener =>
+            {
+                await listener.ConsumeAsync(StubProducer(), An.Event().Named("test1").WithNoFilePath().Passed(), default);
+            })
+            .Act()
+            .Assert(async root =>
+            {
+                await Assert.That(root.Module().ModuleId()).Contains("assembly/TestClass/test1");
+            });
+    }
+
+    [Test("strips parameters from UID")]
+    public async Task StripsParametersFromUid()
+    {
+        await ListenerFixture
+            .Arrange(async listener =>
+            {
+                var node = new TestNode
+                {
+                    Uid = new TestNodeUid("assembly/TestClass/TestMethod(1, 2)"),
+                    DisplayName = "TestMethod",
+                    Properties = new PropertyBag(new PassedTestNodeStateProperty()),
+                };
+                var update = new TestNodeUpdateMessage(default, node);
+                await listener.ConsumeAsync(StubProducer(), update, default);
+            })
+            .Act()
+            .Assert(async root =>
+            {
+                await Assert.That(root.Module().Test().FullName()).IsEqualTo("assembly/TestClass/TestMethod");
+            });
+    }
+
+    [Test("uses display name as test name")]
+    public async Task UsesDisplayNameAsTestName()
+    {
+        await ListenerFixture
+            .Arrange(async listener =>
+            {
+                await listener.ConsumeAsync(StubProducer(), An.Event().Named("Should_add_numbers").Passed(), default);
+            })
+            .Act()
+            .Assert(async root =>
+            {
+                await Assert.That(root.Module().Test().Name()).IsEqualTo("Should_add_numbers");
+            });
+    }
+
+    [Test("ignores in-progress nodes")]
+    public async Task IgnoresInProgressNodes()
+    {
+        await ListenerFixture
+            .Arrange(async listener =>
+            {
+                await listener.ConsumeAsync(StubProducer(), An.Event().Named("test1").InProgress(), default);
+            })
+            .Act()
+            .AssertNoOutput();
+    }
+
+    [Test("ignores discovered nodes")]
+    public async Task IgnoresDiscoveredNodes()
+    {
+        await ListenerFixture
+            .Arrange(async listener =>
+            {
+                await listener.ConsumeAsync(StubProducer(), An.Event().Named("test1").Discovered(), default);
+            })
+            .Act()
+            .AssertNoOutput();
+    }
+
+    [Test("maps error state to failed")]
+    public async Task MapsErrorStateToFailed()
+    {
+        await ListenerFixture
+            .Arrange(async listener =>
+            {
+                await listener.ConsumeAsync(StubProducer(), An.Event().Named("test1").Error("setup exploded"), default);
+            })
+            .Act()
+            .Assert(async root =>
+            {
+                var test = root.Module().Test();
+                await Assert.That(test.State()).IsEqualTo("failed");
+                await Assert.That(test.ErrorMessage()).Contains("setup exploded");
+            });
+    }
+
+    [Test("ignores non-TestNodeUpdateMessage data")]
+    public async Task IgnoresNonTestNodeUpdateMessageData()
+    {
+        await ListenerFixture
+            .Arrange(async listener =>
+            {
+                var stubData = new MtpStubs.StubData("not a test update", null);
+                await listener.ConsumeAsync(StubProducer(), stubData, default);
+            })
+            .Act()
+            .AssertNoOutput();
+    }
+
+    [Test("failed with no exception and no explanation produces empty errors array")]
+    public async Task FailedWithNoExceptionNoExplanationProducesEmptyErrorsArray()
+    {
+        await ListenerFixture
+            .Arrange(async listener =>
+            {
+                await listener.ConsumeAsync(StubProducer(), An.Event().Named("test1").FailedBare(), default);
+            })
+            .Act()
+            .Assert(async root =>
+            {
+                var test = root.Module().Test();
+                await Assert.That(test.State()).IsEqualTo("failed");
+                await Assert.That(test.GetProperty("errors").GetArrayLength()).IsEqualTo(0);
+            });
+    }
+
+    [Test("error with no exception and no explanation produces empty errors array")]
+    public async Task ErrorWithNoExceptionNoExplanationProducesEmptyErrorsArray()
+    {
+        await ListenerFixture
+            .Arrange(async listener =>
+            {
+                await listener.ConsumeAsync(StubProducer(), An.Event().Named("test1").ErrorBare(), default);
+            })
+            .Act()
+            .Assert(async root =>
+            {
+                var test = root.Module().Test();
+                await Assert.That(test.State()).IsEqualTo("failed");
+                await Assert.That(test.GetProperty("errors").GetArrayLength()).IsEqualTo(0);
+            });
+    }
+
+    [Test("clears results between sessions")]
+    public async Task ClearsResultsBetweenSessions()
+    {
+        var (listener, readJson, tempDir) = ListenerFixture.Create();
+        try
+        {
+            // First session: one passing test produces output
+            await listener.OnTestSessionStartingAsync(StubSessionContext());
+            await listener.ConsumeAsync(StubProducer(), An.Event().Named("test1").Passed(), default);
+            await listener.OnTestSessionFinishingAsync(StubSessionContext());
+
+            await Assert.That(ListenerFixture.HasTestJson(tempDir)).IsTrue();
+
+            // Delete the file so we can detect whether session 2 writes
+            File.Delete(ListenerFixture.JsonPath(tempDir));
+
+            // Second session: no tests, should not recreate file
+            await listener.OnTestSessionStartingAsync(StubSessionContext());
+            await listener.OnTestSessionFinishingAsync(StubSessionContext());
+
+            await Assert.That(ListenerFixture.HasTestJson(tempDir)).IsFalse();
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir)) Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Test("groups tests by module")]
+    public async Task GroupsTestsByModule()
+    {
+        await ListenerFixture
+            .Arrange(async listener =>
+            {
+                await listener.ConsumeAsync(StubProducer(), An.Event().Named("test1").InFile("/src/ModuleA.cs").Passed(), default);
+                await listener.ConsumeAsync(StubProducer(), An.Event().Named("test2").InFile("/src/ModuleB.cs").Passed(), default);
+                await listener.ConsumeAsync(StubProducer(), An.Event().Named("test3").InFile("/src/ModuleA.cs").Passed(), default);
+            })
+            .Act()
+            .Assert(async root =>
+            {
+                var modules = root.GetProperty("testModules");
+                await Assert.That(modules.GetArrayLength()).IsEqualTo(2);
+                await Assert.That(modules[0].ModuleId()).IsEqualTo("/src/ModuleA.cs");
+                await Assert.That(modules[0].Tests().GetArrayLength()).IsEqualTo(2);
+                await Assert.That(modules[1].ModuleId()).IsEqualTo("/src/ModuleB.cs");
+                await Assert.That(modules[1].Tests().GetArrayLength()).IsEqualTo(1);
+            });
+    }
+
+    [Test("uses camelCase keys and omits nulls")]
+    public async Task UsesCamelCaseKeysAndOmitsNulls()
+    {
+        await ListenerFixture
+            .Arrange(async listener =>
+            {
+                await listener.ConsumeAsync(StubProducer(), An.Event().Named("test1").Passed(), default);
+            })
+            .Act()
+            .Assert(async root =>
+            {
+                await Assert.That(root.TryGetProperty("testModules", out _)).IsTrue();
+                await Assert.That(root.TryGetProperty("TestModules", out _)).IsFalse();
+
+                var module = root.Module();
+                await Assert.That(module.TryGetProperty("moduleId", out _)).IsTrue();
+                await Assert.That(module.TryGetProperty("ModuleId", out _)).IsFalse();
+
+                await Assert.That(module.Test().TryGetProperty("errors", out _)).IsFalse();
+            });
+    }
+
+    [Test("escapes quotes in error messages")]
+    public async Task EscapesQuotesInErrorMessages()
+    {
+        await ListenerFixture
+            .Arrange(async listener =>
+            {
+                await listener.ConsumeAsync(StubProducer(), An.Event().Named("test1").Failed("Expected \"hello\" but got \"world\""), default);
+            })
+            .Act()
+            .Assert(async root =>
+            {
+                await Assert.That(root.Module().Test().ErrorMessage()).Contains("Expected \"hello\" but got \"world\"");
+            });
+    }
+
+    [Test("escapes newlines in error messages")]
+    public async Task EscapesNewlinesInErrorMessages()
+    {
+        await ListenerFixture
+            .Arrange(async listener =>
+            {
+                await listener.ConsumeAsync(StubProducer(), An.Event().Named("test1").Failed("line1\nline2\nline3"), default);
+            })
+            .Act()
+            .Assert(async root =>
+            {
+                await Assert.That(root.Module().Test().ErrorMessage()).Contains("line1\nline2\nline3");
+            });
+    }
+
+    [Test("escapes backslashes in error messages")]
+    public async Task EscapesBackslashesInErrorMessages()
+    {
+        await ListenerFixture
+            .Arrange(async listener =>
+            {
+                await listener.ConsumeAsync(StubProducer(), An.Event().Named("test1").Failed("path: C:\\Users\\test\\file.cs"), default);
+            })
+            .Act()
+            .Assert(async root =>
+            {
+                await Assert.That(root.Module().Test().ErrorMessage()).Contains("C:\\Users\\test\\file.cs");
+            });
+    }
+
+    [Test("handles concurrent ConsumeAsync calls safely")]
+    public async Task HandlesConcurrentConsumeAsyncCallsSafely()
+    {
+        var (listener, readJson, tempDir) = ListenerFixture.Create();
+        try
+        {
+            await listener.OnTestSessionStartingAsync(StubSessionContext());
+
+            using var barrier = new Barrier(100);
+            var tasks = Enumerable.Range(0, 100).Select(i => Task.Run(async () =>
+            {
+                barrier.SignalAndWait();
+                await listener.ConsumeAsync(
+                    StubProducer(),
+                    An.Event().Named($"Test_{i}").InFile("/src/Tests.cs").Passed(),
+                    default);
+            }));
+            await Task.WhenAll(tasks);
+
+            await listener.OnTestSessionFinishingAsync(StubSessionContext());
+
+            var root = TestJsonAssert.Parse(readJson());
+            var tests = root.Module().Tests();
+            await Assert.That(tests.GetArrayLength()).IsEqualTo(100);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir)) Directory.Delete(tempDir, true);
+        }
+    }
+
+    // Coverage: exercises IExtension property getters (lines 19-26) which are
+    // called by MTP framework via reflection but never by application code.
+    [Test("exposes correct IExtension metadata")]
+    public async Task ExposesCorrectExtensionMetadata()
+    {
+        var (listener, _, tempDir) = ListenerFixture.Create();
+        try
+        {
+            await Assert.That(listener.Uid).IsNotNull();
+            await Assert.That(listener.Version).IsNotNull();
+            await Assert.That(listener.DisplayName).IsNotNull();
+            await Assert.That(listener.Description).IsNotNull();
+
+            var enabled = await listener.IsEnabledAsync();
+            await Assert.That(enabled).IsTrue();
+
+            await Assert.That(listener.DataTypesConsumed).Contains(typeof(TestNodeUpdateMessage));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir)) Directory.Delete(tempDir, true);
+        }
+    }
+}

--- a/reporters/dotnet/TddGuard.Dotnet.Tests/TddGuardRegistration.cs
+++ b/reporters/dotnet/TddGuard.Dotnet.Tests/TddGuardRegistration.cs
@@ -1,0 +1,19 @@
+using Microsoft.Testing.Platform.Builder;
+
+#pragma warning disable CA1050 // Declare types in namespaces
+#pragma warning disable CA1515 // MTP codegen requires this class to be public
+
+/// <summary>
+/// MTP builder hook required by the <c>TestingPlatformBuilderHook</c> MSBuild item
+/// in the test csproj. MTP codegen expects this class in the global namespace with
+/// exactly this name and signature. Left empty so the extension tests can construct
+/// <see cref="TddGuard.Dotnet.TddGuardListener"/> directly with a spy writer.
+/// </summary>
+public static class TestingPlatformBuilderHook
+{
+    public static void AddExtensions(ITestApplicationBuilder builder, string[] _)
+    {
+        // Don't register TDD Guard when running the test project's own tests.
+        // The extension tests use a spy writer via direct construction.
+    }
+}

--- a/reporters/dotnet/TddGuard.Dotnet.Tests/TempDir.cs
+++ b/reporters/dotnet/TddGuard.Dotnet.Tests/TempDir.cs
@@ -1,0 +1,17 @@
+namespace TddGuard.Dotnet.Tests;
+
+internal static class TempDir
+{
+    internal static async Task Run(Func<string, Task> test)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        try
+        {
+            await test(dir);
+        }
+        finally
+        {
+            if (Directory.Exists(dir)) Directory.Delete(dir, true);
+        }
+    }
+}

--- a/reporters/dotnet/TddGuard.Dotnet.Tests/TestEventBuilder.cs
+++ b/reporters/dotnet/TddGuard.Dotnet.Tests/TestEventBuilder.cs
@@ -1,0 +1,69 @@
+using Microsoft.Testing.Platform.Extensions.Messages;
+
+namespace TddGuard.Dotnet.Tests;
+
+/// <summary>
+/// Test Data Builder for MTP test events. Provides a fluent API that hides
+/// MTP-specific types behind intent-revealing methods.
+/// Entry point: <c>An.Event()</c>
+/// </summary>
+internal sealed class TestEventBuilder
+{
+    private string _name = "test1";
+    private string? _filePath = "DefaultFile.cs";
+
+    internal TestEventBuilder Named(string name)
+    {
+        _name = name;
+        return this;
+    }
+
+    internal TestEventBuilder InFile(string filePath)
+    {
+        _filePath = filePath;
+        return this;
+    }
+
+    internal TestEventBuilder WithNoFilePath()
+    {
+        _filePath = null;
+        return this;
+    }
+
+    internal TestNodeUpdateMessage Passed()
+        => MtpStubs.MakeTestUpdate(_name, new PassedTestNodeStateProperty(), _filePath);
+
+    internal TestNodeUpdateMessage Failed(string message)
+        => MtpStubs.MakeTestUpdate(_name,
+            new FailedTestNodeStateProperty(new InvalidOperationException(message), message), _filePath);
+
+    internal TestNodeUpdateMessage FailedWithExplanation(string explanation)
+        => MtpStubs.MakeTestUpdate(_name, new FailedTestNodeStateProperty(explanation), _filePath);
+
+    internal TestNodeUpdateMessage FailedBare()
+        => MtpStubs.MakeTestUpdate(_name, new FailedTestNodeStateProperty(), _filePath);
+
+    internal TestNodeUpdateMessage Skipped()
+        => MtpStubs.MakeTestUpdate(_name, new SkippedTestNodeStateProperty(), _filePath);
+
+    internal TestNodeUpdateMessage Error(string message)
+        => MtpStubs.MakeTestUpdate(_name,
+            new ErrorTestNodeStateProperty(new InvalidOperationException(message), message), _filePath);
+
+    internal TestNodeUpdateMessage ErrorBare()
+        => MtpStubs.MakeTestUpdate(_name, new ErrorTestNodeStateProperty(), _filePath);
+
+    internal TestNodeUpdateMessage InProgress()
+        => MtpStubs.MakeTestUpdate(_name, new InProgressTestNodeStateProperty(), _filePath);
+
+    internal TestNodeUpdateMessage Discovered()
+        => MtpStubs.MakeTestUpdate(_name, new DiscoveredTestNodeStateProperty(), _filePath);
+}
+
+/// <summary>
+/// Entry point for the Test Data Builder: <c>An.Event().Named("x").Passed()</c>
+/// </summary>
+internal static class An
+{
+    internal static TestEventBuilder Event() => new();
+}

--- a/reporters/dotnet/TddGuard.Dotnet.Tests/TestJsonAssert.cs
+++ b/reporters/dotnet/TddGuard.Dotnet.Tests/TestJsonAssert.cs
@@ -1,0 +1,39 @@
+using System.Text.Json;
+
+namespace TddGuard.Dotnet.Tests;
+
+internal static class TestJsonAssert
+{
+    internal static JsonElement Parse(string json)
+        => JsonDocument.Parse(json).RootElement;
+
+    internal static string Reason(this JsonElement root)
+        => root.GetProperty("reason").GetString()!;
+
+    internal static JsonElement Module(this JsonElement root, int index = 0)
+        => root.GetProperty("testModules")[index];
+
+    internal static string ModuleId(this JsonElement module)
+        => module.GetProperty("moduleId").GetString()!;
+
+    internal static JsonElement Tests(this JsonElement module)
+        => module.GetProperty("tests");
+
+    internal static JsonElement Test(this JsonElement module, int index = 0)
+        => module.GetProperty("tests")[index];
+
+    internal static string State(this JsonElement test)
+        => test.GetProperty("state").GetString()!;
+
+    internal static string Name(this JsonElement test)
+        => test.GetProperty("name").GetString()!;
+
+    internal static string FullName(this JsonElement test)
+        => test.GetProperty("fullName").GetString()!;
+
+    internal static bool HasErrors(this JsonElement test)
+        => test.TryGetProperty("errors", out _);
+
+    internal static string ErrorMessage(this JsonElement test, int index = 0)
+        => test.GetProperty("errors")[index].GetProperty("message").GetString()!;
+}

--- a/reporters/dotnet/TddGuard.Dotnet.Tests/TestNodeMapperTests.cs
+++ b/reporters/dotnet/TddGuard.Dotnet.Tests/TestNodeMapperTests.cs
@@ -1,0 +1,39 @@
+using TddGuard.Dotnet.Core;
+
+namespace TddGuard.Dotnet.Tests;
+
+internal sealed class TestNodeMapperTests
+{
+    [Test("preserves UID when no parentheses present")]
+    public async Task PreservesUidWithNoParentheses()
+    {
+        var input = new TestNodeInput("assembly/Class/Method", "Method", "/file.cs", new Core.TestState.Passed());
+        var result = input.ToCollectedResult();
+        await Assert.That(result.FullName).IsEqualTo("assembly/Class/Method");
+    }
+
+    [Test("strips at first open parenthesis including nested parens")]
+    public async Task StripsAtFirstOpenParenthesis()
+    {
+        var input = new TestNodeInput("assembly/Class/Method((1, 2))", "Method", "/file.cs", new Core.TestState.Passed());
+        var result = input.ToCollectedResult();
+        await Assert.That(result.FullName).IsEqualTo("assembly/Class/Method");
+    }
+
+    [Test("handles empty UID string without throwing")]
+    public async Task HandlesEmptyUidString()
+    {
+        var input = new TestNodeInput(string.Empty, "Method", "/file.cs", new Core.TestState.Passed());
+        var result = input.ToCollectedResult();
+        await Assert.That(result.FullName).IsEqualTo(string.Empty);
+    }
+
+    [Test("uses stripped fullName as module ID when file path is null")]
+    public async Task UsesStrippedFullNameAsModuleIdWhenFilePathNull()
+    {
+        var input = new TestNodeInput("assembly/Class/Method(1)", "Method", null, new Core.TestState.Passed());
+        var result = input.ToCollectedResult();
+        await Assert.That(result.ModuleId).IsEqualTo("assembly/Class/Method");
+        await Assert.That(result.FullName).IsEqualTo("assembly/Class/Method");
+    }
+}

--- a/reporters/dotnet/TddGuard.Dotnet.Tests/TestReportWriterTests.cs
+++ b/reporters/dotnet/TddGuard.Dotnet.Tests/TestReportWriterTests.cs
@@ -1,0 +1,38 @@
+using TddGuard.Dotnet.Core;
+
+namespace TddGuard.Dotnet.Tests;
+
+internal sealed class TestReportWriterTests
+{
+    [Test("returns Skipped when results collection is empty")]
+    public async Task ReturnsSkippedWhenEmpty()
+    {
+        IReadOnlyCollection<CollectedResult> results = [];
+        WriteTestOutput spy = _ => throw new InvalidOperationException("should not be called");
+
+        var result = results.WriteTestReport(spy);
+
+        await Assert.That(result is WriteResult.Skipped).IsTrue();
+    }
+
+    [Test("delegates to writeOutput when results are present")]
+    public async Task DelegatesToWriteOutputWhenResultsPresent()
+    {
+        TestRunOutput? captured = null;
+        WriteTestOutput spy = output =>
+        {
+            captured = output;
+            return new WriteResult.Success();
+        };
+        IReadOnlyCollection<CollectedResult> results =
+        [
+            new("test1", "Ns.Class.test1", "Module.cs", new Core.TestState.Passed())
+        ];
+
+        var result = results.WriteTestReport(spy);
+
+        await Assert.That(result is WriteResult.Success).IsTrue();
+        await Assert.That(captured).IsNotNull();
+        await Assert.That(captured!.TestModules.Count).IsEqualTo(1);
+    }
+}

--- a/reporters/dotnet/TddGuard.Dotnet/TddGuard.Dotnet.csproj
+++ b/reporters/dotnet/TddGuard.Dotnet/TddGuard.Dotnet.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PackageId>TddGuard.Dotnet</PackageId>
+    <Version>0.1.0</Version>
+    <Description>TDD Guard test reporter for Microsoft Testing Platform V2</Description>
+    <Authors>Ed Blackburn</Authors>
+    <PackageTags>testing;tdd;test-driven-development;mtp;testing-platform;claude</PackageTags>
+    <RepositoryUrl>https://github.com/nizos/tdd-guard</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Testing.Platform" Version="2.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../TddGuard.Dotnet.Core/TddGuard.Dotnet.Core.csproj" />
+  </ItemGroup>
+
+  <!-- Include MSBuild props for auto-registration in consuming projects -->
+  <ItemGroup>
+    <None Include="buildTransitive/**/*.props" Pack="true" PackagePath="buildTransitive" />
+  </ItemGroup>
+
+</Project>

--- a/reporters/dotnet/TddGuard.Dotnet/TddGuardBuilder.cs
+++ b/reporters/dotnet/TddGuard.Dotnet/TddGuardBuilder.cs
@@ -1,0 +1,40 @@
+using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Extensions;
+using TddGuard.Dotnet.Core;
+
+namespace TddGuard.Dotnet;
+
+/// <summary>
+/// Public entry point for MTP V2 auto-registration.
+/// Called by the generated <c>TestingPlatformBuilderHook</c> via the
+/// <c>buildTransitive/*.props</c> MSBuild item shipped in the NuGet package.
+/// </summary>
+public static class TddGuardBuilder
+{
+    public static void Register(
+        ITestApplicationBuilder builder,
+        GetEnvironmentVariable? getEnv = null,
+        GetCurrentWorkingDirectory? getCwd = null,
+        LogDiagnostic? log = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        var diagnose = log ?? (msg => Console.Error.WriteLine($"[tdd-guard-dotnet] {msg}"));
+
+        ProjectRootResolver.Resolve(
+            getEnv ?? Environment.GetEnvironmentVariable,
+            getCwd ?? Directory.GetCurrentDirectory)
+        .LogOnError(diagnose)
+        .Switch(
+            root =>
+            {
+                var write = ReportFileWriter.Create(root.Path)
+                    .WithDiagnostics(diagnose);
+                var compositeFactory = new CompositeExtensionFactory<TddGuardListener>(
+                    () => new TddGuardListener(write));
+                builder.TestHost.AddTestSessionLifetimeHandle(compositeFactory);
+                builder.TestHost.AddDataConsumer(compositeFactory);
+            },
+            error => { } // Disabled — already logged by LogOnError
+        );
+    }
+}

--- a/reporters/dotnet/TddGuard.Dotnet/TddGuardListener.cs
+++ b/reporters/dotnet/TddGuard.Dotnet/TddGuardListener.cs
@@ -1,0 +1,76 @@
+using Microsoft.Testing.Platform.Extensions;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.TestHost;
+using Microsoft.Testing.Platform.Services;
+using System.Collections.Concurrent;
+using TddGuard.Dotnet.Core;
+
+namespace TddGuard.Dotnet;
+
+/// <summary>
+/// MTP V2 extension that consumes <see cref="TestNodeUpdateMessage"/> events
+/// and writes a <c>test.json</c> report when the test session finishes.
+/// Thread-safe: concurrent <see cref="ConsumeAsync"/> calls are supported via <see cref="ConcurrentQueue{T}"/>.
+/// </summary>
+public sealed class TddGuardListener(WriteTestOutput writeOutput) : ITestSessionLifetimeHandler, IDataConsumer, IExtension
+{
+    private ConcurrentQueue<CollectedResult> _results = [];
+
+    public string Uid => "TddGuard.Dotnet";
+    public string Version => "1.0.0";
+    public string DisplayName => "TDD Guard";
+    public string Description => "TDD Guard test reporter";
+
+    public Type[] DataTypesConsumed => [typeof(TestNodeUpdateMessage)];
+
+    public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+    public Task OnTestSessionStartingAsync(ITestSessionContext testSessionContext)
+    {
+        _results = [];
+        return Task.CompletedTask;
+    }
+
+    public Task OnTestSessionFinishingAsync(ITestSessionContext testSessionContext)
+    {
+        _results.WriteTestReport(writeOutput);
+        return Task.CompletedTask;
+    }
+
+    public Task ConsumeAsync(IDataProducer dataProducer, IData value, CancellationToken cancellationToken)
+    {
+        if (value is not TestNodeUpdateMessage update)
+            return Task.CompletedTask;
+
+        var node = update.TestNode;
+        // MTP fires Discovered during enumeration and InProgress when a test starts;
+        // we only collect terminal states (Passed, Failed, Skipped, Error).
+        var stateProperty = node.Properties.SingleOrDefault<TestNodeStateProperty>();
+        if (stateProperty is null or InProgressTestNodeStateProperty or DiscoveredTestNodeStateProperty)
+            return Task.CompletedTask;
+
+        Core.TestState state = stateProperty switch
+        {
+            FailedTestNodeStateProperty f => new Core.TestState.Failed(
+                f.Exception is not null ? [new TestEntryError(f.Exception.Message)]
+                : !string.IsNullOrEmpty(f.Explanation) ? [new TestEntryError(f.Explanation)]
+                : []),
+            ErrorTestNodeStateProperty e => new Core.TestState.Failed(
+                e.Exception is not null ? [new TestEntryError(e.Exception.Message)]
+                : !string.IsNullOrEmpty(e.Explanation) ? [new TestEntryError(e.Explanation)]
+                : []),
+            SkippedTestNodeStateProperty => new Core.TestState.Skipped(),
+            _ => new Core.TestState.Passed(),
+        };
+        var filePath = node.Properties.SingleOrDefault<TestFileLocationProperty>()?.FilePath;
+
+        var input = new TestNodeInput(
+            Uid: node.Uid.Value,
+            DisplayName: node.DisplayName,
+            FilePath: filePath,
+            State: state);
+
+        _results.Enqueue(input.ToCollectedResult());
+        return Task.CompletedTask;
+    }
+}

--- a/reporters/dotnet/TddGuard.Dotnet/TestingPlatformBuilderHook.cs
+++ b/reporters/dotnet/TddGuard.Dotnet/TestingPlatformBuilderHook.cs
@@ -1,0 +1,9 @@
+using Microsoft.Testing.Platform.Builder;
+
+namespace TddGuard.Dotnet;
+
+public static class TestingPlatformBuilderHook
+{
+    public static void AddExtensions(ITestApplicationBuilder builder, string[] _)
+        => TddGuardBuilder.Register(builder);
+}

--- a/reporters/dotnet/TddGuard.Dotnet/buildTransitive/net10.0/TddGuard.Dotnet.props
+++ b/reporters/dotnet/TddGuard.Dotnet/buildTransitive/net10.0/TddGuard.Dotnet.props
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+    <ItemGroup>
+        <TestingPlatformBuilderHook Include="TddGuard.Dotnet">
+            <DisplayName>TDD Guard</DisplayName>
+            <TypeFullName>TddGuard.Dotnet.TestingPlatformBuilderHook</TypeFullName>
+        </TestingPlatformBuilderHook>
+    </ItemGroup>
+</Project>

--- a/reporters/dotnet/global.json
+++ b/reporters/dotnet/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}


### PR DESCRIPTION
## Summary

Adds the .NET reporter core: an MTP V2 (Microsoft Testing Platform) in-process extension that captures test results and writes `.claude/tdd-guard/data/test.json`. Framework-agnostic — any MTP V2-hosted framework works without reporter changes.

## Scope

Following your guidance on issue #84 ("keeping the PR focused and the initial implementation simple will make it much easier for me to review") and the shape you accepted for the JUnit5 reporter (#160 — listener, collector, JSON writer, SPI/hook registration, build wrapper, unit tests only), this PR is scoped identically:

- `TddGuard.Dotnet.Core/` — pure domain types and functions, no MTP dependency
- `TddGuard.Dotnet/` — the MTP V2 extension (listener + builder hook)
- `TddGuard.Dotnet.Tests/` — unit and property-based tests only

No `src/` changes. No CI changes (separate PR, stacked on this one). No integration test factory or framework compatibility smoke tests (separate PRs, same as JUnit5's follow-up sequence).

## Design

- Domain logic (Core) has zero MTP dependency — testable without a test host
- Errors are values: `ProjectRootResolver.Resolve()` returns `OneOf<ProjectRoot, ResolveError>`, no exceptions for flow control
- Per ADR-010: when neither `TDD_GUARD_PROJECT_ROOT` nor `CLAUDE_PROJECT_DIR` is set, the extension disables itself and logs to stderr — it does not silently fall back to cwd
- Cross-platform path handling: `Path.GetFullPath()` + normalized comparison for the ancestor-of-cwd check (handles Windows separators, case-insensitivity, trailing separators, macOS `/var` → `/private/var` symlinks)

## Testing

70 unit tests, including property-based roundtrip serialization (FsCheck). All pass on .NET 10.

## Distribution

Planned for NuGet.org, published by you — following up separately on issue #84.

## Stacked PRs

This is the first of a stack of 4 PRs decomposing the reporter the way JUnit5 landed:

1. This PR — core reporter
2. `feat/dotnet-ci` → CI build step
3. `feat/dotnet-integration-tests` → Node integration test factory + minimal fixtures
4. `feat/dotnet-framework-compat` → framework compatibility smoke tests

Each is based on the previous, so they'll show as small incremental diffs once opened.