### PR TITLE
fix: fail open on validation errors and respect Claude Code model config

### DIFF
--- a/src/config/Config.test.ts
+++ b/src/config/Config.test.ts
@@ -500,6 +500,15 @@ describe('Config', () => {
   })
 
   describe('modelVersion', () => {
+    // Clear all model-related env vars so tests are hermetic regardless of
+    // the host environment (Claude Code sessions inject ANTHROPIC_* vars).
+    beforeEach(() => {
+      delete process.env.TDD_GUARD_MODEL_VERSION
+      delete process.env.ANTHROPIC_DEFAULT_SONNET_MODEL
+      delete process.env.ANTHROPIC_MODEL
+      delete process.env.ANTHROPIC_SMALL_FAST_MODEL
+    })
+
     test('returns default model version when no configuration provided', () => {
       const config = new Config()
 
@@ -531,6 +540,56 @@ describe('Config', () => {
       const config = new Config()
 
       expect(config.modelVersion).toBe('claude-haiku-3-0')
+    })
+
+    test('falls back to ANTHROPIC_DEFAULT_SONNET_MODEL when TDD_GUARD_MODEL_VERSION is not set', () => {
+      delete process.env.TDD_GUARD_MODEL_VERSION
+      process.env.ANTHROPIC_DEFAULT_SONNET_MODEL = 'my-provider/sonnet'
+
+      const config = new Config()
+
+      expect(config.modelVersion).toBe('my-provider/sonnet')
+    })
+
+    test('falls back to ANTHROPIC_MODEL when other model env vars are not set', () => {
+      delete process.env.TDD_GUARD_MODEL_VERSION
+      delete process.env.ANTHROPIC_DEFAULT_SONNET_MODEL
+      process.env.ANTHROPIC_MODEL = 'my-provider/main'
+
+      const config = new Config()
+
+      expect(config.modelVersion).toBe('my-provider/main')
+    })
+
+    test('falls back to ANTHROPIC_SMALL_FAST_MODEL when only it is set', () => {
+      delete process.env.TDD_GUARD_MODEL_VERSION
+      delete process.env.ANTHROPIC_DEFAULT_SONNET_MODEL
+      delete process.env.ANTHROPIC_MODEL
+      process.env.ANTHROPIC_SMALL_FAST_MODEL = 'my-provider/fast'
+
+      const config = new Config()
+
+      expect(config.modelVersion).toBe('my-provider/fast')
+    })
+
+    test('TDD_GUARD_MODEL_VERSION takes precedence over Claude Code env fallbacks', () => {
+      process.env.TDD_GUARD_MODEL_VERSION = 'my-provider/guard'
+      process.env.ANTHROPIC_DEFAULT_SONNET_MODEL = 'my-provider/sonnet'
+      process.env.ANTHROPIC_MODEL = 'my-provider/main'
+
+      const config = new Config()
+
+      expect(config.modelVersion).toBe('my-provider/guard')
+    })
+
+    test('ignores empty fallback env vars', () => {
+      delete process.env.TDD_GUARD_MODEL_VERSION
+      process.env.ANTHROPIC_DEFAULT_SONNET_MODEL = ''
+      process.env.ANTHROPIC_MODEL = '  '
+
+      const config = new Config()
+
+      expect(config.modelVersion).toBe(DEFAULT_MODEL_VERSION)
     })
   })
 

--- a/src/config/Config.test.ts
+++ b/src/config/Config.test.ts
@@ -591,6 +591,30 @@ describe('Config', () => {
 
       expect(config.modelVersion).toBe(DEFAULT_MODEL_VERSION)
     })
+
+    test('strips Claude Code context-window suffix from env fallbacks', () => {
+      delete process.env.TDD_GUARD_MODEL_VERSION
+      delete process.env.ANTHROPIC_MODEL
+      process.env.ANTHROPIC_DEFAULT_SONNET_MODEL = 'my-provider/model[1M]'
+
+      const config = new Config()
+
+      expect(config.modelVersion).toBe('my-provider/model')
+    })
+
+    test('strips context-window suffix from TDD_GUARD_MODEL_VERSION', () => {
+      process.env.TDD_GUARD_MODEL_VERSION = 'my-provider/model[200k]'
+
+      const config = new Config()
+
+      expect(config.modelVersion).toBe('my-provider/model')
+    })
+
+    test('strips context-window suffix from options', () => {
+      const config = new Config({ modelVersion: 'my-provider/model[2M]' })
+
+      expect(config.modelVersion).toBe('my-provider/model')
+    })
   })
 
   describe('linterType', () => {

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -26,6 +26,29 @@ const MODEL_VERSION_ENV_FALLBACKS = [
   'ANTHROPIC_SMALL_FAST_MODEL',
 ] as const
 
+/**
+ * Strip context-window suffixes (e.g. "[1M]") that Claude Code appends to
+ * model identifiers in its own env vars. Those suffixes are valid for the
+ * model selector UI but are not part of the model ID sent to the API.
+ * Implemented with indexOf instead of a regex to avoid super-linear
+ * backtracking on untrusted input.
+ */
+function stripModelContextSuffix(model: string): string {
+  const trimmed = model.trim()
+  if (!trimmed.endsWith(']')) {
+    return trimmed
+  }
+  const openBracket = trimmed.lastIndexOf('[', trimmed.length - 2)
+  if (openBracket === -1) {
+    return trimmed
+  }
+  const inner = trimmed.slice(openBracket + 1, trimmed.length - 1)
+  if (/^\d+[kKmM]?$/.test(inner)) {
+    return trimmed.slice(0, openBracket).trimEnd()
+  }
+  return trimmed
+}
+
 const VALID_CLIENTS = new Set<string>(['api', 'cli', 'sdk'])
 const MODEL_TYPE_TO_CLIENT: Record<string, ClientType> = {
   anthropic_api: 'api',
@@ -125,16 +148,16 @@ export class Config {
 
   private getModelVersion(options?: ConfigOptions): string {
     if (options?.modelVersion) {
-      return options.modelVersion
+      return stripModelContextSuffix(options.modelVersion)
     }
     const envValue = process.env.TDD_GUARD_MODEL_VERSION
     if (envValue && envValue.trim() !== '') {
-      return envValue
+      return stripModelContextSuffix(envValue)
     }
     for (const envName of MODEL_VERSION_ENV_FALLBACKS) {
       const fallbackValue = process.env[envName]
       if (fallbackValue && fallbackValue.trim() !== '') {
-        return fallbackValue
+        return stripModelContextSuffix(fallbackValue)
       }
     }
     return DEFAULT_MODEL_VERSION

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -13,6 +13,19 @@ export const DEFAULT_MODEL_VERSION = 'claude-sonnet-4-6'
 export const DEFAULT_CLIENT: ClientType = 'sdk'
 export const DEFAULT_DATA_DIR = path.join('.claude', 'tdd-guard', 'data')
 
+/**
+ * Environment variables used as fallbacks when TDD_GUARD_MODEL_VERSION is
+ * not set. This lets the validation model follow the Claude Code session's
+ * own model configuration, which is essential when running against custom
+ * API endpoints (ANTHROPIC_BASE_URL) that do not serve the hardcoded
+ * default model.
+ */
+const MODEL_VERSION_ENV_FALLBACKS = [
+  'ANTHROPIC_DEFAULT_SONNET_MODEL',
+  'ANTHROPIC_MODEL',
+  'ANTHROPIC_SMALL_FAST_MODEL',
+] as const
+
 const VALID_CLIENTS = new Set<string>(['api', 'cli', 'sdk'])
 const MODEL_TYPE_TO_CLIENT: Record<string, ClientType> = {
   anthropic_api: 'api',
@@ -111,11 +124,20 @@ export class Config {
   }
 
   private getModelVersion(options?: ConfigOptions): string {
-    return (
-      options?.modelVersion ??
-      process.env.TDD_GUARD_MODEL_VERSION ??
-      DEFAULT_MODEL_VERSION
-    )
+    if (options?.modelVersion) {
+      return options.modelVersion
+    }
+    const envValue = process.env.TDD_GUARD_MODEL_VERSION
+    if (envValue && envValue.trim() !== '') {
+      return envValue
+    }
+    for (const envName of MODEL_VERSION_ENV_FALLBACKS) {
+      const fallbackValue = process.env[envName]
+      if (fallbackValue && fallbackValue.trim() !== '') {
+        return fallbackValue
+      }
+    }
+    return DEFAULT_MODEL_VERSION
   }
 
   private getValidationClient(options?: ConfigOptions): ClientType {

--- a/src/guard/GuardManager.test.ts
+++ b/src/guard/GuardManager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { GuardManager } from './GuardManager'
 import { Storage } from '../storage/Storage'
 import { MemoryStorage } from '../storage/MemoryStorage'
@@ -324,6 +324,70 @@ describe('GuardManager', () => {
       expect(
         await guardManager.shouldIgnoreFile('app/views/users/show.html.erb')
       ).toBe(true)
+    })
+
+    describe('absolute paths reported by Claude Code hooks', () => {
+      const originalCwd = process.cwd
+
+      afterEach(() => {
+        process.cwd = originalCwd
+      })
+
+      it('matches directory patterns against paths inside the working directory', async () => {
+        process.cwd = vi
+          .fn()
+          .mockReturnValue('/home/user/project') as typeof process.cwd
+        await setupIgnorePatterns(storage, ['test/**', 'dist/**'])
+
+        expect(
+          await guardManager.shouldIgnoreFile(
+            '/home/user/project/test/hello.py'
+          )
+        ).toBe(true)
+        expect(
+          await guardManager.shouldIgnoreFile(
+            '/home/user/project/dist/assets/app.js'
+          )
+        ).toBe(true)
+        expect(
+          await guardManager.shouldIgnoreFile('/home/user/project/src/hello.py')
+        ).toBe(false)
+      })
+
+      it('matches Windows-style paths with backslashes', async () => {
+        process.cwd = vi
+          .fn()
+          .mockReturnValue('E:\\Desktop') as typeof process.cwd
+        await setupIgnorePatterns(storage, ['test/**'])
+
+        expect(
+          await guardManager.shouldIgnoreFile('E:\\Desktop\\test\\hello.py')
+        ).toBe(true)
+        expect(
+          await guardManager.shouldIgnoreFile('E:\\Desktop\\src\\hello.py')
+        ).toBe(false)
+      })
+
+      it('matches default patterns for absolute paths', async () => {
+        process.cwd = vi
+          .fn()
+          .mockReturnValue('/home/user/project') as typeof process.cwd
+
+        expect(
+          await guardManager.shouldIgnoreFile('/home/user/project/README.md')
+        ).toBe(true)
+      })
+
+      it('still matches ** patterns for paths outside the working directory', async () => {
+        process.cwd = vi
+          .fn()
+          .mockReturnValue('/home/user/project') as typeof process.cwd
+        await setupIgnorePatterns(storage, ['**/test/**'])
+
+        expect(
+          await guardManager.shouldIgnoreFile('/home/user/other/test/a.py')
+        ).toBe(true)
+      })
     })
   })
 })

--- a/src/guard/GuardManager.ts
+++ b/src/guard/GuardManager.ts
@@ -52,9 +52,10 @@ export class GuardManager {
 
   async shouldIgnoreFile(filePath: string): Promise<boolean> {
     const patterns = await this.getIgnorePatterns()
+    const pathToMatch = normalizePathForMatching(filePath)
 
     return patterns.some((pattern) =>
-      minimatch(filePath, pattern, this.minimatchOptions)
+      minimatch(pathToMatch, pattern, this.minimatchOptions)
     )
   }
 
@@ -81,4 +82,23 @@ export class GuardManager {
       return null
     }
   }
+}
+
+/**
+ * Normalize a file path for glob matching:
+ * - Convert backslashes to forward slashes (Windows support)
+ * - Strip the current working directory prefix so user-facing patterns like
+ *   `test` directory patterns match the absolute paths that Claude Code hook
+ *   events report (e.g. /home/user/project/test/hello.py).
+ *
+ * Paths outside the current working directory are left as-is; globstar
+ * patterns still match them.
+ */
+function normalizePathForMatching(filePath: string): string {
+  const forwardPath = filePath.replace(/\\/g, '/')
+  const cwd = process.cwd().replace(/\\/g, '/')
+  if (forwardPath.startsWith(`${cwd}/`)) {
+    return forwardPath.slice(cwd.length + 1)
+  }
+  return forwardPath
 }

--- a/src/validation/validator.test.ts
+++ b/src/validation/validator.test.ts
@@ -212,45 +212,45 @@ This violates TDD principles as explained in the numbered list above.
     })
   })
 
-  describe('error handling', () => {
-    test('should block when model client throws error', async () => {
+  describe('error handling (fail open)', () => {
+    test('fails open when model client throws error', async () => {
       const { result } = await runValidator(
         new Error('Command failed: claude not found')
       )
 
-      expect(result.decision).toBe('block')
-      expect(result.reason).toContain('Error during validation')
+      expect(result.decision).toBeUndefined()
+      expect(result.reason).toContain('Validation skipped')
       expect(result.reason).toContain('Command failed: claude not found')
     })
 
-    test('should block when model returns invalid JSON', async () => {
+    test('fails open when model returns invalid JSON', async () => {
       const { result } = await runValidator(
         `\`\`\`json\ninvalid json content\n\`\`\``
       )
 
-      expect(result.decision).toBe('block')
-      expect(result.reason).toContain('Error during validation')
+      expect(result.decision).toBeUndefined()
+      expect(result.reason).toContain('Validation skipped')
     })
 
-    test('should provide special message when model returns no response', async () => {
+    test('fails open with specific message when model returns no response', async () => {
       const { result } = await runValidator('')
 
-      expect(result.decision).toBe('block')
-      expect(result.reason).not.toContain('Error during validation')
-      expect(result.reason).toBe('No response from model, try again')
+      expect(result.decision).toBeUndefined()
+      expect(result.reason).toContain('No response from model')
+      expect(result.reason).not.toContain('Validation skipped')
     })
 
     test('surfaces the model response when it is not valid JSON', async () => {
       const { result } = await runValidator('Credit balance too low')
 
-      expect(result.decision).toBe('block')
+      expect(result.decision).toBeUndefined()
       expect(result.reason).toContain('Credit balance too low')
     })
 
-    test('blocks when the response has no usable decision', async () => {
+    test('fails open when the response has no usable decision', async () => {
       const { result } = await runValidator('{"reason": "explanation only"}')
 
-      expect(result.decision).toBe('block')
+      expect(result.decision).toBeUndefined()
       expect(result.reason).toContain('explanation only')
     })
   })

--- a/src/validation/validator.ts
+++ b/src/validation/validator.ts
@@ -18,13 +18,24 @@ export async function validator(
     const prompt = generateDynamicContext(context)
     const response = await modelClient.ask(prompt)
     if (!response) {
-      return block('No response from model, try again')
+      // Fail open: an unresponsive validation model must not block the
+      // user's file operations.
+      return {
+        decision: undefined,
+        reason: 'No response from model, validation skipped',
+      }
     }
     return parseModelResponse(response)
   } catch (error) {
     const errorMessage =
       error instanceof Error ? error.message : 'Unknown error'
-    return block(`Error during validation: ${errorMessage}`)
+    // Fail open: validation infrastructure errors (API outages, unsupported
+    // model names, etc.) must not block the user's file operations. The
+    // reason is surfaced so the failure is visible without interrupting work.
+    return {
+      decision: undefined,
+      reason: `Validation skipped: ${errorMessage}`,
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Four related fixes for a class of failure where TDD Guard **blocks every file operation** in environments that use a custom API endpoint (`ANTHROPIC_BASE_URL`, e.g. third-party or self-hosted Anthropic-compatible gateways):

1. **Fail open on validation infrastructure errors** (`validator.ts`)
   - The validator returned `block` for *every* exception from the model client (API 400s, timeouts, malformed responses). A broken validation pipeline therefore blocked the user's Write/Edit entirely.
   - Now: errors return an `allow`-style result (`decision: undefined`) with the reason surfaced, so work is never blocked by validation infrastructure.

2. **Resolve the validation model from Claude Code's own model configuration** (`Config.ts`)
   - `DEFAULT_MODEL_VERSION = 'claude-sonnet-4-6'` was sent verbatim to the API endpoint. Custom gateways that don't serve that model rejected every validation request with 400 — which, combined with #1, blocked all file operations with no way out.
   - Now: `TDD_GUARD_MODEL_VERSION` > `ANTHROPIC_DEFAULT_SONNET_MODEL` > `ANTHROPIC_MODEL` > `ANTHROPIC_SMALL_FAST_MODEL` > hardcoded default.

3. **Match ignore patterns against cwd-relative paths** (`GuardManager.ts`)
   - Claude Code hook events report **absolute** file paths, but ignore patterns are documented relative to the project root (`test/**`). Absolute paths never matched, so documented patterns were silently ineffective.
   - Now: paths are normalized to forward slashes and stripped of the cwd prefix before glob matching (Windows-friendly); paths outside cwd still match `**/` patterns.

4. **Strip Claude Code context-window suffixes from resolved model ids** (`Config.ts`)
   - Claude Code appends `[1M]`-style suffixes to model ids in its env vars (e.g. `ANTHROPIC_DEFAULT_SONNET_MODEL=my-provider/model[1M]`). Fix #2 would pass that suffixed id verbatim to the API, which rejects it as an unknown model. The suffix is now stripped from every model source. The stripping implementation avoids regex backtracking (sonarjs/slow-regex clean).

## Reproduction

With `ANTHROPIC_BASE_URL` pointing at a gateway that doesn't serve `claude-sonnet-4-6`:

1. Enable the plugin hook (`Write|Edit|MultiEdit|TodoWrite` → `npx tdd-guard@latest`).
2. Attempt any `Write` — every single one fails with `Error during validation: API Error: 400 ... 当前平台无此模型` and the file operation is blocked.

## Testing

- New unit tests for all four fixes (fail-open error handling, model env fallback precedence, context-suffix stripping, absolute/Windows path matching).
- `npx vitest run` (unit + golangci-lint projects): 798 passing. The 8 remaining failures are pre-existing and environment-specific (verified identical on the unmodified baseline): 5 require the `golangci-lint` binary, 2 require `rubocop`, 1 asserts POSIX path separators on Windows.
- `npx tsc --noEmit` passes; `eslint` passes on all changed files; `prettier` clean.
- Real end-to-end scenario comparison against the custom gateway reproduced the 400 → blocked behavior on the baseline and verified each fix on the new build.

## Notes

- The upstream README points new projects to **Probity**; this PR keeps TDD Guard usable for the projects that rely on it.