### PR TITLE
fix: parse .tsx test files with the TSX grammar

### DIFF
--- a/src/hooks/fileTypeDetection.ts
+++ b/src/hooks/fileTypeDetection.ts
@@ -16,6 +16,7 @@ export function isTestFile(filePath: string): boolean {
 
 export type Language =
   | 'typescript'
+  | 'tsx'
   | 'javascript'
   | 'python'
   | 'go'
@@ -25,7 +26,7 @@ export type Language =
 
 const EXTENSION_TO_LANGUAGE: Record<string, Language> = {
   '.ts': 'typescript',
-  '.tsx': 'typescript',
+  '.tsx': 'tsx',
   '.js': 'javascript',
   '.jsx': 'javascript',
   '.py': 'python',

--- a/src/hooks/processHookData.test.ts
+++ b/src/hooks/processHookData.test.ts
@@ -474,6 +474,28 @@ it('should subtract', () => { expect(subtract(3, 1)).toBe(2) })`,
       expect(sut.validatorHasBeenCalled()).toBe(true)
     })
 
+    it('should call validator when adding multiple tests to a tsx test file', async () => {
+      const multipleTestEdit = {
+        ...EDIT_HOOK_DATA,
+        tool_input: {
+          file_path: 'src/Button.test.tsx',
+          old_string: '',
+          new_string: `it('renders the label', () => {
+  render(<Button label="Save" />)
+  expect(screen.getByText('Save')).toBeTruthy()
+})
+it('renders children', () => {
+  render(<Button label="Save"><span>body</span></Button>)
+  expect(screen.getByText('body')).toBeTruthy()
+})`,
+        },
+      }
+
+      await sut.process(multipleTestEdit)
+
+      expect(sut.validatorHasBeenCalled()).toBe(true)
+    })
+
     it('should call validator for edits to implementation files', async () => {
       const implFileEdit = {
         ...EDIT_HOOK_DATA,

--- a/src/hooks/testCounter.test.ts
+++ b/src/hooks/testCounter.test.ts
@@ -55,6 +55,25 @@ describe('countTestDefinitions', () => {
     })
   })
 
+  describe('tsx', () => {
+    it('should count each test in a file that renders JSX', () => {
+      const code = `it('renders the label', () => {
+        render(<Button label="Save" />)
+      })
+      it('renders children', () => {
+        render(<Button label="Save"><span>body</span></Button>)
+      })`
+      expect(countTestDefinitions(code, 'tsx')).toBe(2)
+    })
+
+    it('should count a test that renders a generic component', () => {
+      const code = `it('renders a typed list', () => {
+        render(<List<string> items={['a']} />)
+      })`
+      expect(countTestDefinitions(code, 'tsx')).toBe(1)
+    })
+  })
+
   describe('python', () => {
     it('should count a single pytest function', () => {
       const code = `def test_addition():

--- a/src/hooks/testCounter.ts
+++ b/src/hooks/testCounter.ts
@@ -29,6 +29,12 @@ const JS_TEST_PATTERNS = [
   { pattern: 'it.concurrent($$$A)' },
 ]
 
+const JS_LANGS = {
+  javascript: Lang.JavaScript,
+  typescript: Lang.TypeScript,
+  tsx: Lang.Tsx,
+} as const
+
 function countJavaScriptTests(code: string, lang: Lang): number {
   const ast = parse(lang, code)
   const root = ast.root()
@@ -152,10 +158,8 @@ export function countTestDefinitions(code: string, language: Language): number {
   switch (language) {
     case 'javascript':
     case 'typescript':
-      return countJavaScriptTests(
-        code,
-        language === 'typescript' ? Lang.TypeScript : Lang.JavaScript
-      )
+    case 'tsx':
+      return countJavaScriptTests(code, JS_LANGS[language])
     case 'python':
       return countPythonTests(code)
     case 'go':

--- a/test/hooks/fileTypeDetection.test.ts
+++ b/test/hooks/fileTypeDetection.test.ts
@@ -31,7 +31,7 @@ describe('isTestFile', () => {
 describe('detectLanguage', () => {
   const cases = [
     { path: 'src/calc.ts', expected: 'typescript' },
-    { path: 'src/calc.tsx', expected: 'typescript' },
+    { path: 'src/calc.tsx', expected: 'tsx' },
     { path: 'src/calc.js', expected: 'javascript' },
     { path: 'src/calc.jsx', expected: 'javascript' },
     { path: 'src/calc.py', expected: 'python' },


### PR DESCRIPTION
## What this fixes

`detectLanguage` maps `.tsx` to `typescript`, and `countTestDefinitions` parses `typescript` with `Lang.TypeScript`. That grammar cannot parse JSX, so a `.tsx` test file parses with error nodes that swallow the call expressions around them, and the pre-filter undercounts the tests an edit adds.

The consequence is not only a missed fast path. `isAllowedTestAddition` skips validation when exactly one test is added, so an edit that adds **two** tests to a `.tsx` file is counted as one and allowed straight through — the case the guard exists to catch.

Measured on `main` before the change, with the patterns the counter uses:

| Snippet | `Lang.TypeScript` | `Lang.Tsx` | Correct |
|---|---|---|---|
| two `it(...)` tests, each rendering JSX | 1 | 2 | 2 |
| one `it(...)` rendering `<List<string> … />` | 0 | 1 | 1 |

The first row is the soundness hole; the second sends a legitimate single test addition through full validation instead of the fast path.

## The change

`.tsx` now maps to its own `tsx` language, and the counter picks the grammar from the language rather than from a shared `typescript` label. `.ts` keeps `Lang.TypeScript` — the TSX grammar is not a superset, so pointing everything at it would break type assertions and generic arrow functions in plain `.ts`.

`Language` and `detectLanguage` are internal to `src/hooks/`, so nothing exported from `src/index.ts` changes.

## Tests

Written first, and each fails on `main`:

- `src/hooks/testCounter.test.ts` — two tests in a JSX-rendering file count as 2; a test rendering a generic component counts as 1.
- `src/hooks/processHookData.test.ts` — an edit adding two tests to `src/Button.test.tsx` reaches the validator. This is the behavioural one; before the change it returns `allow` without validating.
- `test/hooks/fileTypeDetection.test.ts` — the existing `.tsx` expectation is updated to `tsx`.

Both halves of the fix are load-bearing, checked by reverting each on its own: with `.tsx` mapped back to `typescript`, 4 tests fail; with the `tsx` entry pointed back at `Lang.TypeScript`, 6 fail.

`npm run build`, `npx tsc --noEmit`, `npm run lint` and `prettier --check` are clean. In the unit suite the only failures are the RuboCop and golangci-lint cases, which fail identically on an unmodified checkout here because those linters are not installed on this machine; the same is true of the reporter integration tests and `test/integration/validator.core.test.ts`.
